### PR TITLE
fix(fine-tuning): adjust dataset formatting for synthetic complaints

### DIFF
--- a/synthetic_data_complete.json
+++ b/synthetic_data_complete.json
@@ -1,0 +1,10002 @@
+[
+  {
+    "instruction": "You complain about art.",
+    "response": "Please, not the art again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "distressed",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I've heard that complaint before, haven't I?",
+    "sentiment": -0.3,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.2559090909090909,
+    "style": "annoyed",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "How dare you!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.06,
+    "style": "outraged",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "It's just weather, deal with it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2127777777777778,
+    "style": "dismissive",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "You always make it sound like you were some helpless little martyr.",
+    "sentiment": 0.10625000000000001,
+    "subjectivity": 0.45,
+    "word_count": 12,
+    "complexity_score": 0.24884615384615386,
+    "style": "resentful",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "You never stop going on about your goals!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.20166666666666666,
+    "style": "frustrated",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I'm sorry to hear that you're struggling in your relationships.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.3026923076923077,
+    "style": "concerned",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "Oh, I'm sure the squirrels are just loving your complaints too!",
+    "sentiment": 0.625,
+    "subjectivity": 0.9194444444444444,
+    "word_count": 11,
+    "complexity_score": 0.2671428571428571,
+    "style": "sarcastic",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm getting tired of hearing myself complain!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 7,
+    "complexity_score": 0.30166666666666664,
+    "style": "frustrated",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "Oh, here we go again with the healthcare lecture!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "annoyed",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "Just move them to your backyard already.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "impatient",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "I'm not complaining, they're just... haunting my thoughts.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.2873076923076923,
+    "style": "disturbed",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "You dare complain when I'm the one planning them?!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.15666666666666668,
+    "style": "outraged",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "You're like a broken garbage disposal, always complaining but never helping!",
+    "sentiment": -0.5,
+    "subjectivity": 0.4,
+    "word_count": 11,
+    "complexity_score": 0.3457142857142857,
+    "style": "fed up",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "I wish people understood that mental health isn't something to just 'snap out of.'",
+    "sentiment": -0.1,
+    "subjectivity": 0.2,
+    "word_count": 14,
+    "complexity_score": 0.355,
+    "style": "dismayed",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "Oh, here we go again...",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "discouraged",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "I note your concern regarding our workplace culture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.3127777777777778,
+    "style": "dispassionate",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "Oh, here we go again with the 'workplace culture' grumbles.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.31038461538461537,
+    "style": "annoyed",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "disappointed",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "Oh, you must be the pot calling the kettle black.",
+    "sentiment": -0.16666666666666666,
+    "subjectivity": 0.43333333333333335,
+    "word_count": 10,
+    "complexity_score": 0.21333333333333332,
+    "style": "bitter",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "But you're the one who always brings it up?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.165,
+    "style": "upset",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "I'm over here listening, not talking!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.25722222222222224,
+    "style": "fed up",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "It's like talking to a wall, this insurance.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.265,
+    "style": "unhappy",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Just solve it already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.15500000000000003,
+    "style": "impatient",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Spare me the friend drama, please.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "dismissive",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "Oh, for crying out loud, you're just as bad by posting this!",
+    "sentiment": -0.3249999999999999,
+    "subjectivity": 0.6888888888888888,
+    "word_count": 12,
+    "complexity_score": 0.32125000000000004,
+    "style": "exasperated",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Oh, I'd love to hear your complaints about earning too much!",
+    "sentiment": 0.375,
+    "subjectivity": 0.4,
+    "word_count": 11,
+    "complexity_score": 0.28857142857142853,
+    "style": "ironic",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I guess you'd rather manage yourself, then.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "disappointed",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "I'm sorry, but aren't we humans the ones encroaching on their habitats?",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.30874999999999997,
+    "style": "troubled",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Oh, for goodness' sake, you're the only person I know who complains about having too many opportunities!",
+    "sentiment": 0.3125,
+    "subjectivity": 0.75,
+    "word_count": 17,
+    "complexity_score": 0.41181818181818186,
+    "style": "exasperated",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "I'm worried, let's discuss why you're not enjoying your meals.",
+    "sentiment": -0.25,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.305,
+    "style": "concerned",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, do enlighten me on how I'm supposed to enjoy the weather when it's raining indoors?",
+    "sentiment": 0.4,
+    "subjectivity": 0.5,
+    "word_count": 16,
+    "complexity_score": 0.41500000000000004,
+    "style": "annoyed",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "fed up",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "Oh, please don't talk about it, our bins are overflowing again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.27166666666666667,
+    "style": "distressed",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "Books... they whisper when I'm alone!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.17944444444444446,
+    "style": "disturbed",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "I guess I'll just have to suffer in silence.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "discouraged",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "I guess I'll just tell the coffee maker to make my meetings for me too.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.2961764705882353,
+    "style": "sarcastic",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "irritated",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "Well, if you'd just stop thinking, we wouldn't have this problem!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.30874999999999997,
+    "style": "exasperated",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "Oh, here we go again, reminiscing won't change anything!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.25653846153846155,
+    "style": "annoyed",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Unbelievable! How dare you complain about pets, the very creatures who bring us joy and companionship!",
+    "sentiment": 0.29583333333333334,
+    "subjectivity": 0.5,
+    "word_count": 16,
+    "complexity_score": 0.2425,
+    "style": "outraged",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "Enough talk, what are you doing to help?",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "impatient",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Oh, you mean like how everyone else does?",
+    "sentiment": -0.3125,
+    "subjectivity": 0.6875,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "ironic",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "I guess I'll just have to pay Uncle Sam alone again this year.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.22499999999999998,
+    "style": "disappointed",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "Oh, not this again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "disappointed",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "Can't we just focus on well-being without the constant complaints?",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 10,
+    "complexity_score": 0.36333333333333334,
+    "style": "impatient",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I'll feel safer knowing you're awake.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.17944444444444446,
+    "style": "ironic",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "I thought we were supposed to celebrate progress, not dwell on its flaws!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.3516666666666667,
+    "style": "upset",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "I've noted your concern regarding childcare.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.27,
+    "style": "dispassionate",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "Really, you'd think they were performing open-heart surgery!",
+    "sentiment": 0.25,
+    "subjectivity": 0.2,
+    "word_count": 8,
+    "complexity_score": 0.2740909090909091,
+    "style": "dismayed",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "I feel like I'm always the problem, even when trying my best.",
+    "sentiment": 1.0,
+    "subjectivity": 0.3,
+    "word_count": 12,
+    "complexity_score": 0.27166666666666667,
+    "style": "disappointed",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "Your words echo like nails on my coffin.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.20166666666666666,
+    "style": "disturbed",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "It's not like we're chipping away at rocks in the rain, is it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.33147058823529413,
+    "style": "bitter",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "frustrated",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm sorry, are you looking for someone else to listen?",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "irritated",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "You're just another noisy cog in the train's perpetual motion, aren't you?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3197058823529412,
+    "style": "disturbed",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "I note your concern regarding work volume.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "dispassionate",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "I'm sorry, but I can't change my policy.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "dismayed",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "Have you seen the state of our streets? This is an outrage!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.18357142857142858,
+    "style": "outraged",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "I worry that your complaints might go unheard.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.25722222222222224,
+    "style": "worried",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I worry about our safety, but nobody seems to care.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.205,
+    "style": "unhappy",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I suppose if you don't like it, you could always try silence.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.29833333333333334,
+    "style": "bored",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "I hear you, but my veins are filled with insurance paperwork!",
+    "sentiment": 0.5,
+    "subjectivity": 0.9,
+    "word_count": 11,
+    "complexity_score": 0.2796153846153846,
+    "style": "disturbed",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "Well, isn't that just a melody of complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22863636363636367,
+    "style": "disappointed",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, could you possibly find another hobby?",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 7,
+    "complexity_score": 0.22388888888888892,
+    "style": "annoyed",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, for the love of heaven, it's just 'nice weather we're having'!",
+    "sentiment": 0.625,
+    "subjectivity": 0.8,
+    "word_count": 12,
+    "complexity_score": 0.32555555555555554,
+    "style": "exasperated",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Oh, you'd have them too if you slept like the rest of us.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.29625,
+    "style": "resentful",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "I suppose I should clean up after you too, huh?",
+    "sentiment": 0.3666666666666667,
+    "subjectivity": 0.7000000000000001,
+    "word_count": 10,
+    "complexity_score": 0.2383333333333333,
+    "style": "resentful",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "Oh, please, the system's not meant for your comfort.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.24884615384615386,
+    "style": "dismissive",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "I'm not just complaining, I genuinely care about improving our work environment.",
+    "sentiment": 0.4,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.3516666666666667,
+    "style": "upset",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Really? With the economy like this?",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 6,
+    "complexity_score": 0.185,
+    "style": "dismayed",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "Oh, don't get me started on your TV habits!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2383333333333333,
+    "style": "irritated",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I see you've taken up the old pastime.",
+    "sentiment": 0.1,
+    "subjectivity": 0.2,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "disappointed",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "I wish I could say my dreams were as big as my complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.1,
+    "word_count": 13,
+    "complexity_score": 0.26,
+    "style": "disheartened",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I'll just switch to breathing air from Mars, problem solved.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "ironic",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "I acknowledge receipt of your concerns regarding your challenges.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.38,
+    "style": "dispassionate",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I'm always the last to know, aren't I?",
+    "sentiment": 0.0,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "dissatisfied",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Well, if you'd just communicate like normal people!",
+    "sentiment": 0.1875,
+    "subjectivity": 0.6499999999999999,
+    "word_count": 8,
+    "complexity_score": 0.2559090909090909,
+    "style": "exasperated",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "You're always whining about your salary!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2075,
+    "style": "angry",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "Just get it done already.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.15666666666666668,
+    "style": "impatient",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Oh, you're still here? Commute's never over, is it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.15916666666666665,
+    "style": "disturbed",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I find your self-deprecation tiresome.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 5,
+    "complexity_score": 0.22333333333333333,
+    "style": "displeased",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "Oh, so now you're blaming the animals too?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.23772727272727273,
+    "style": "upset",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Pets? You're the real monsters!",
+    "sentiment": 0.25,
+    "subjectivity": 0.30000000000000004,
+    "word_count": 5,
+    "complexity_score": 0.11,
+    "style": "disturbed",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm disappointed, I thought I could do better.",
+    "sentiment": -0.125,
+    "subjectivity": 0.625,
+    "word_count": 8,
+    "complexity_score": 0.23772727272727273,
+    "style": "disappointed",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I'm tired of hearing you gripe about management!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 8,
+    "complexity_score": 0.29000000000000004,
+    "style": "aggravated",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "Why don't you just squeeze them between your shift at the factory and your second job, like I did?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 19,
+    "complexity_score": 0.4254545454545455,
+    "style": "disturbed",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "I suppose if you'd recycled your complaints, we wouldn't be having this conversation.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.36676470588235294,
+    "style": "disappointed",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "I thought you'd be thrilled, it's finally cooling down!",
+    "sentiment": 0.13518518518518519,
+    "subjectivity": 0.662962962962963,
+    "word_count": 9,
+    "complexity_score": 0.3180769230769231,
+    "style": "upset",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "Oh, you would.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "dismissive",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "You're like a bird complaining about the sky.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.25,
+    "style": "bitter",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm always disappointed by who I am.",
+    "sentiment": -0.75,
+    "subjectivity": 0.75,
+    "word_count": 7,
+    "complexity_score": 0.2127777777777778,
+    "style": "dissatisfied",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "I suppose if I could change them, they'd be my reality.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.28857142857142853,
+    "style": "bitter",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "Oh, here we go again with the security lectures.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "annoyed",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "I'm sorry, was I not supposed to express my frustrations?",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.2873076923076923,
+    "style": "upset",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I'm worried that you're having difficulties with the current management.",
+    "sentiment": 0.0,
+    "subjectivity": 0.4,
+    "word_count": 10,
+    "complexity_score": 0.36423076923076925,
+    "style": "concerned",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "I've heard that tune before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.1907142857142857,
+    "style": "dissatisfied",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "I'm sorry to hear that, is there anything we can do to improve your working space?",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 16,
+    "complexity_score": 0.36394736842105263,
+    "style": "concerned",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "I'll only be quiet when they start making films about your silence.",
+    "sentiment": 0.0,
+    "subjectivity": 0.6666666666666666,
+    "word_count": 12,
+    "complexity_score": 0.26,
+    "style": "ironic",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I'm just trying to be honest, but it seems like I'm my own worst critic.",
+    "sentiment": 0.06666666666666665,
+    "subjectivity": 0.9666666666666667,
+    "word_count": 15,
+    "complexity_score": 0.3007894736842105,
+    "style": "dismayed",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "Well, if you think I'm bad, you should meet me.",
+    "sentiment": -0.6999999999999998,
+    "subjectivity": 0.6666666666666666,
+    "word_count": 10,
+    "complexity_score": 0.23142857142857143,
+    "style": "fed up",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "I'm sick of your endless complaints about sports!",
+    "sentiment": -0.43526785714285715,
+    "subjectivity": 0.8035714285714286,
+    "word_count": 8,
+    "complexity_score": 0.29000000000000004,
+    "style": "angry",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "I still can't believe I paid for this bland, overpriced mess.",
+    "sentiment": -0.17083333333333334,
+    "subjectivity": 0.5041666666666667,
+    "word_count": 11,
+    "complexity_score": 0.28857142857142853,
+    "style": "unhappy",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "How dare you complain about our beloved companions!",
+    "sentiment": 0.875,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.30166666666666664,
+    "style": "outraged",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "Oh, here we go again with the 'smartphones are ruining everything' lecture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3516666666666667,
+    "style": "annoyed",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I've heard your relationship woes a thousand times already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2740909090909091,
+    "style": "aggravated",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "You express dissatisfaction with current offerings.",
+    "sentiment": 0.0,
+    "subjectivity": 0.4,
+    "word_count": 6,
+    "complexity_score": 0.37642857142857145,
+    "style": "dispassionate",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "My complaints fall on deaf ears.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.205,
+    "style": "unhappy",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "I'll just add it to the ever-growing list of things that'll never get done.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.2961764705882353,
+    "style": "dismissive",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "I guess I should've read the fine print.",
+    "sentiment": 0.4166666666666667,
+    "subjectivity": 0.5,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "disappointed",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I've heard more harmony at a heavy metal concert than living here.",
+    "sentiment": 0.15,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.31,
+    "style": "dissatisfied",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "I guess it's just easier to point fingers than understand the system.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.28857142857142853,
+    "style": "discouraged",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "Oh, you're still harping on about taxes?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.25,
+    "style": "resentful",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "Just eat it already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.15500000000000003,
+    "style": "impatient",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "I've heard it all before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.14785714285714285,
+    "style": "fed up",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "Here we go again, moan about mental health.",
+    "sentiment": -0.1,
+    "subjectivity": 0.2,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "fed up",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "I suppose it's just another episode of the same old thing.",
+    "sentiment": 0.05,
+    "subjectivity": 0.1625,
+    "word_count": 11,
+    "complexity_score": 0.31038461538461537,
+    "style": "bored",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "You always harp on 'little me', when will you cut it out?",
+    "sentiment": -0.1875,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.29166666666666663,
+    "style": "frustrated",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "It's not like you can just return it to the store.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.21807692307692308,
+    "style": "bitter",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Despite my best efforts, it seems I'll never reach them.",
+    "sentiment": 1.0,
+    "subjectivity": 0.3,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "unhappy",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "I guess I'm just destined to be bored.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "discouraged",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "I wish my biggest problem was just the paperwork.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.27,
+    "style": "ironic",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "I worry that these persistent home repairs might be indicative of something more serious.",
+    "sentiment": 0.08333333333333334,
+    "subjectivity": 0.5833333333333333,
+    "word_count": 14,
+    "complexity_score": 0.39833333333333326,
+    "style": "worried",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "exasperated",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "How dare you criticize my childhood self!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "outraged",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "You're always whining about healthcare, but you never lift a finger to help.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.30874999999999997,
+    "style": "resentful",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "I worry that my complaints might overshadow my true gratitude for those very successes.",
+    "sentiment": 0.275,
+    "subjectivity": 0.475,
+    "word_count": 14,
+    "complexity_score": 0.37166666666666665,
+    "style": "worried",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "You're always harping on about the environment!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.29055555555555557,
+    "style": "aggravated",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "Oh, joy, not this again.",
+    "sentiment": 0.8,
+    "subjectivity": 0.2,
+    "word_count": 5,
+    "complexity_score": 0.12,
+    "style": "bored",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "Oh, boo-hoo for you and your accomplishments.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.25722222222222224,
+    "style": "bitter",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "I'm just trying to survive this rat race, and you have the audacity to complain about job stress?!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 18,
+    "complexity_score": 0.23318181818181818,
+    "style": "outraged",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "Spare me the whining, it's just a few coins from your kingly pile.",
+    "sentiment": -0.2,
+    "subjectivity": 0.1,
+    "word_count": 13,
+    "complexity_score": 0.28375,
+    "style": "dismissive",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Well, aren't we just the picture of gratitude.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.265,
+    "style": "annoyed",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "I can't change what happened, yet it's all I think about.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.27166666666666667,
+    "style": "unhappy",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "Spare me the drama, watch something else.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.17944444444444446,
+    "style": "dismissive",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Oh, here we go again with the Wi-Fi blues!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.1922727272727273,
+    "style": "fed up",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "I wish you could just enjoy the melody.",
+    "sentiment": 0.4,
+    "subjectivity": 0.5,
+    "word_count": 8,
+    "complexity_score": 0.135,
+    "style": "disappointed",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I'm tired of hearing your constant complaints about our security!",
+    "sentiment": -0.2,
+    "subjectivity": 0.5166666666666666,
+    "word_count": 10,
+    "complexity_score": 0.36333333333333334,
+    "style": "angry",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "You always find fault, never fun!",
+    "sentiment": -0.1875,
+    "subjectivity": 0.2,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "angry",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "You'd rather walk than hear me gripe about this bus.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.22999999999999998,
+    "style": "resentful",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "Please, not tonight!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.15500000000000003,
+    "style": "distressed",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "Oh, you're still whining about those ink-smudged pages?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.265,
+    "style": "aggravated",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "I guess I should just accept that the premiums are high because the coverage is low.",
+    "sentiment": 0.08,
+    "subjectivity": 0.42000000000000004,
+    "word_count": 16,
+    "complexity_score": 0.3608823529411765,
+    "style": "disheartened",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Oh, you're here to gripe about the commute again?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2383333333333333,
+    "style": "resentful",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Your complaints fall on deaf ears, I won't part ways with my furry family!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.3138235294117647,
+    "style": "angry",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "I'm not a mortgage broker, you know.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "displeased",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Oh, not again with the commute complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.25722222222222224,
+    "style": "disappointed",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "I swear, if you mention rent one more time...",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "annoyed",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I guess we should just let the planet burn.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.15,
+    "style": "dissatisfied",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "But what if we can't afford to move?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "worried",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "Oh, poor you.",
+    "sentiment": -0.4,
+    "subjectivity": 0.6,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "dismissive",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "You're just miserable because you can't teleport like the rest of us, huh?",
+    "sentiment": -1.0,
+    "subjectivity": 1.0,
+    "word_count": 13,
+    "complexity_score": 0.3785294117647059,
+    "style": "disturbed",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "Is it too much to ask for just one nice day?",
+    "sentiment": 0.4,
+    "subjectivity": 0.6,
+    "word_count": 11,
+    "complexity_score": 0.205,
+    "style": "discouraged",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "I suppose it's just your hobby to make lawyers richer.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.24666666666666665,
+    "style": "ironic",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "Oh, you're still going on about them?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.21,
+    "style": "disappointed",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "It's always something, isn't it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.17944444444444446,
+    "style": "unhappy",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "I've heard louder nails.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "dismissive",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "I dread going to work because of all the complaints I have about my coworkers.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.37124999999999997,
+    "style": "unhappy",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "I note your dissatisfaction regarding the internet.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.27,
+    "style": "dispassionate",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "It seems I'm just a burden of complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "discouraged",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "Oh, you're always finding fault with what's on your plate!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2814285714285714,
+    "style": "upset",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "Here we go again, more complaining about something you could've planned yourself.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.3516666666666667,
+    "style": "fed up",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I'm tired of your constant complaining about management!",
+    "sentiment": -0.2,
+    "subjectivity": 0.5166666666666666,
+    "word_count": 8,
+    "complexity_score": 0.33,
+    "style": "angry",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm already aware, no need to rub it in.",
+    "sentiment": 0.25,
+    "subjectivity": 0.25,
+    "word_count": 9,
+    "complexity_score": 0.2383333333333333,
+    "style": "annoyed",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "I'd love to hear your solution while I'm freezing under this glacier you call a 'blanket'.",
+    "sentiment": 0.5,
+    "subjectivity": 0.6,
+    "word_count": 16,
+    "complexity_score": 0.41000000000000003,
+    "style": "sarcastic",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "I'm just trying to understand how I can improve, but you act like it's all my fault.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 17,
+    "complexity_score": 0.3673809523809524,
+    "style": "upset",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "It seems like every day is just another opportunity for me to gripe.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.31,
+    "style": "unhappy",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I observe your concern regarding the environment.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.32,
+    "style": "dispassionate",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I swear, if they leave another dirty spoon in the sink, I'm going to lose it!",
+    "sentiment": -0.75,
+    "subjectivity": 0.8,
+    "word_count": 16,
+    "complexity_score": 0.35,
+    "style": "disturbed",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "How dare you complain about our beloved family members!",
+    "sentiment": 0.875,
+    "subjectivity": 1.0,
+    "word_count": 9,
+    "complexity_score": 0.30000000000000004,
+    "style": "outraged",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "After all the effort I've put in, you dare to criticize my aspirations?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.32749999999999996,
+    "style": "outraged",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "Oh, I'm sorry, next time I'll just leave little Johnny with the wolves.",
+    "sentiment": -0.22916666666666666,
+    "subjectivity": 0.5,
+    "word_count": 13,
+    "complexity_score": 0.2866666666666667,
+    "style": "sarcastic",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "I'm really concerned about our waste management situation.",
+    "sentiment": 0.0,
+    "subjectivity": 0.1,
+    "word_count": 8,
+    "complexity_score": 0.30000000000000004,
+    "style": "worried",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "It's always the same old song and dance, isn't it?",
+    "sentiment": 0.05,
+    "subjectivity": 0.1625,
+    "word_count": 10,
+    "complexity_score": 0.21,
+    "style": "dissatisfied",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "I'm worried, you seem to be complaining about books lately.",
+    "sentiment": -0.3,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "concerned",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Oh, sure, because watching someone else's creativity is so much easier than creating your own.",
+    "sentiment": 0.4333333333333333,
+    "subjectivity": 0.6962962962962962,
+    "word_count": 15,
+    "complexity_score": 0.42184210526315785,
+    "style": "bitter",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "Oh, spare me the book club melodrama.",
+    "sentiment": -0.3,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.17944444444444446,
+    "style": "dismissive",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "Oh, you always find something to gripe about.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "dismissive",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I've heard it all before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.14785714285714285,
+    "style": "dissatisfied",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "exasperated",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I often find myself wishing I could turn off my mind, even just for a moment.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 16,
+    "complexity_score": 0.3088888888888889,
+    "style": "disheartened",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about your life.",
+    "response": "I acknowledge dissatisfaction with current circumstances.",
+    "sentiment": 0.0,
+    "subjectivity": 0.4,
+    "word_count": 6,
+    "complexity_score": 0.37642857142857145,
+    "style": "dispassionate",
+    "topic": "your life"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I'm sick of the constant complaints about management, but no one seems to have any solutions.",
+    "sentiment": -0.35714285714285715,
+    "subjectivity": 0.5952380952380952,
+    "word_count": 16,
+    "complexity_score": 0.4007894736842105,
+    "style": "unhappy",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "upset",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "Spare me the whining, fix it yourself.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.22388888888888892,
+    "style": "impatient",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Well, I'll just buy happiness instead then.",
+    "sentiment": 0.7,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.23,
+    "style": "bitter",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "Oh, here we go again, just what I need, more noise in my head!",
+    "sentiment": 0.625,
+    "subjectivity": 0.5,
+    "word_count": 14,
+    "complexity_score": 0.2866666666666667,
+    "style": "annoyed",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "How dare you grumble about mere home repairs!",
+    "sentiment": -0.625,
+    "subjectivity": 0.5,
+    "word_count": 8,
+    "complexity_score": 0.25722222222222224,
+    "style": "outraged",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "I'm just tired of being my own worst enemy.",
+    "sentiment": -0.26666666666666666,
+    "subjectivity": 0.9,
+    "word_count": 9,
+    "complexity_score": 0.1922727272727273,
+    "style": "discouraged",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "Oh, I just love watching my money evaporate into the housing market's vast, invisible void.",
+    "sentiment": 0.25,
+    "subjectivity": 0.8,
+    "word_count": 15,
+    "complexity_score": 0.38499999999999995,
+    "style": "ironic",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "I'm concerned, you've been watching too much TV again?",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 9,
+    "complexity_score": 0.25653846153846155,
+    "style": "worried",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Why must we always discuss the weather?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "dismayed",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "Oh, here we go again with the endless complaining about books.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 11,
+    "complexity_score": 0.3026923076923077,
+    "style": "annoyed",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "Enough with the privacy complaints already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 6,
+    "complexity_score": 0.3192857142857143,
+    "style": "fed up",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "Oh, I'm just not cut out for this.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.1922727272727273,
+    "style": "discouraged",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "I can't believe you're complaining about music, it's the very pulse of life!",
+    "sentiment": 0.25,
+    "subjectivity": 0.3,
+    "word_count": 13,
+    "complexity_score": 0.3477777777777778,
+    "style": "outraged",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I worry that your complaints might drive a wedge between you and your loved ones.",
+    "sentiment": 0.7,
+    "subjectivity": 0.8,
+    "word_count": 15,
+    "complexity_score": 0.32749999999999996,
+    "style": "worried",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "Music is supposed to make you feel better, not complain!",
+    "sentiment": 0.625,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.24666666666666665,
+    "style": "upset",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "You're stuck in yesterday.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.20666666666666667,
+    "style": "dissatisfied",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "How dare you merely complain when our planet is gasping for breath!",
+    "sentiment": -0.625,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.2796153846153846,
+    "style": "outraged",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I swear, you'd think they were doing it on purpose!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.24884615384615386,
+    "style": "exasperated",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "Oh, you're still going on about that?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.21,
+    "style": "irritated",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "whispers But the train's heartbeat... it never stops.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.23772727272727273,
+    "style": "disturbed",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "I wish you'd just make up your mind!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "frustrated",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Oh, I love wasting time like this!",
+    "sentiment": 0.625,
+    "subjectivity": 0.6,
+    "word_count": 7,
+    "complexity_score": 0.2127777777777778,
+    "style": "ironic",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "I've heard more compelling arguments from my toaster.",
+    "sentiment": 0.4,
+    "subjectivity": 0.55,
+    "word_count": 8,
+    "complexity_score": 0.30000000000000004,
+    "style": "dismissive",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I suppose I'm just doing the best I can, but it never seems quite good enough.",
+    "sentiment": 0.5666666666666667,
+    "subjectivity": 0.46666666666666673,
+    "word_count": 16,
+    "complexity_score": 0.30605263157894735,
+    "style": "disillusioned",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about your feelings.",
+    "response": "I suppose the rain would feel right at home inside me today.",
+    "sentiment": 0.2857142857142857,
+    "subjectivity": 0.5357142857142857,
+    "word_count": 12,
+    "complexity_score": 0.27192307692307693,
+    "style": "disheartened",
+    "topic": "your feelings"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "I've heard that tune before, haven't we all?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22999999999999998,
+    "style": "annoyed",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "Implying you're incapable of changing it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.3075,
+    "style": "displeased",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "Oh, here we go again with the housing woes.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "dismayed",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "It's like shouting into the void.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.245,
+    "style": "disillusioned",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I'm tired of hearing you complain about relationships, yet you're still single.",
+    "sentiment": -0.2357142857142857,
+    "subjectivity": 0.45714285714285713,
+    "word_count": 12,
+    "complexity_score": 0.3525,
+    "style": "unhappy",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "You're all talk and no action.",
+    "sentiment": -0.05,
+    "subjectivity": 0.1,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "disillusioned",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "I'm just tired of fighting this uphill battle.",
+    "sentiment": -0.4,
+    "subjectivity": 0.7,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "discouraged",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "Oh, so you're one of those eco-hypocrites?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.25,
+    "style": "disturbed",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "I've heard the 'dating is hard' lecture ad nauseam.",
+    "sentiment": -0.2916666666666667,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 9,
+    "complexity_score": 0.28,
+    "style": "annoyed",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "You're paying someone else's mortgage while living in their investment.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.3334615384615385,
+    "style": "disillusioned",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "disappointed",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "You're always complaining about technology, even when it's working perfectly.",
+    "sentiment": 1.0,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.3457142857142857,
+    "style": "annoyed",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "Oh no, I hope it doesn't rain today.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.165,
+    "style": "worried",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "Guess who's stuck here till retirement, regardless of the fluorescent lighting.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.3457142857142857,
+    "style": "disillusioned",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about noise.",
+    "response": "Oh, not again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "disappointed",
+    "topic": "noise"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I'm tired of just complaining, let's do something!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 8,
+    "complexity_score": 0.27166666666666667,
+    "style": "frustrated",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "Oh, you just don't understand what it's like.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.2383333333333333,
+    "style": "distressed",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "Well, isn't that just peachy?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.12,
+    "style": "disappointed",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "I'm here if you'd like to talk about what's really bothering you.",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 12,
+    "complexity_score": 0.3025,
+    "style": "concerned",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I hear your complaints, but they fall on deaf ears.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2383333333333333,
+    "style": "displeased",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "Well, if you'd read the fine print, you wouldn't be complaining now!",
+    "sentiment": 0.5208333333333334,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.2961764705882353,
+    "style": "frustrated",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Well, aren't we just a ray of sunshine today?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2383333333333333,
+    "style": "irritated",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "You're always complaining about how much work you have!",
+    "sentiment": 0.25,
+    "subjectivity": 0.2,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "frustrated",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "I've heard enough complaints to circle the globe.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "dismissive",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Please, stop complaining about our beloved pets!",
+    "sentiment": 0.875,
+    "subjectivity": 1.0,
+    "word_count": 7,
+    "complexity_score": 0.25722222222222224,
+    "style": "distressed",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "I'm disappointed you're only focusing on the negatives.",
+    "sentiment": -0.375,
+    "subjectivity": 0.875,
+    "word_count": 8,
+    "complexity_score": 0.3013636363636364,
+    "style": "upset",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "irritated",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "Please, not another lecture on phones!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2575,
+    "style": "distressed",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "I worry that you might be giving up on physical activity.",
+    "sentiment": 0.0,
+    "subjectivity": 0.14285714285714285,
+    "word_count": 11,
+    "complexity_score": 0.29666666666666663,
+    "style": "worried",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "exasperated",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "I guess I'm just never happy.",
+    "sentiment": -0.4,
+    "subjectivity": 1.0,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "discouraged",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "I just don't understand why you always have to complain about social media!",
+    "sentiment": 0.041666666666666664,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 13,
+    "complexity_score": 0.29833333333333334,
+    "style": "distressed",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "irritated",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "I'm just tired of hearing myself say, 'I can't afford that.'",
+    "sentiment": -0.4,
+    "subjectivity": 0.7,
+    "word_count": 11,
+    "complexity_score": 0.2961764705882353,
+    "style": "disheartened",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Oh, the irony of complaining while connected to Wi-Fi.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2922727272727273,
+    "style": "ironic",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "I worry you're losing touch with the real world.",
+    "sentiment": 0.2,
+    "subjectivity": 0.30000000000000004,
+    "word_count": 9,
+    "complexity_score": 0.1922727272727273,
+    "style": "worried",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "You're just adding to the trash problem by complaining!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "angry",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I'm so tired of people complaining about privacy!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 8,
+    "complexity_score": 0.29000000000000004,
+    "style": "distressed",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "I perceive you expressing dissatisfaction regarding television.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.37,
+    "style": "dispassionate",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "Please, don't remind me of the journey I just endured!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "distressed",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "I can't help but feel guilty when others struggle while I succeed.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.28857142857142853,
+    "style": "troubled",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "You know what, I'm tired of hearing about your 'first world problems'!",
+    "sentiment": -0.04375000000000001,
+    "subjectivity": 0.5166666666666666,
+    "word_count": 12,
+    "complexity_score": 0.32749999999999996,
+    "style": "fed up",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "I must've left my complaints at the dream gate last night.",
+    "sentiment": 0.0,
+    "subjectivity": 0.03333333333333333,
+    "word_count": 11,
+    "complexity_score": 0.24884615384615386,
+    "style": "ironic",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, here we go again, another useless exchange.",
+    "sentiment": -0.5,
+    "subjectivity": 0.2,
+    "word_count": 8,
+    "complexity_score": 0.2740909090909091,
+    "style": "resentful",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "Oh, I love the good old days! Especially when they were happening.",
+    "sentiment": 0.33125,
+    "subjectivity": 0.6000000000000001,
+    "word_count": 12,
+    "complexity_score": 0.16583333333333333,
+    "style": "ironic",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "Oh, I'm sorry you find the toxic brew of apathy and cutthroat competition here so disagreeable.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 16,
+    "complexity_score": 0.36394736842105263,
+    "style": "bitter",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I'm sorry to hear that, have you tried talking it out?",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 11,
+    "complexity_score": 0.26,
+    "style": "concerned",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "I note your dissatisfaction with smartphones.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2621428571428571,
+    "style": "dispassionate",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "I'm sick of your constant moaning about money!",
+    "sentiment": -0.35714285714285715,
+    "subjectivity": 0.5952380952380952,
+    "word_count": 8,
+    "complexity_score": 0.29000000000000004,
+    "style": "angry",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "Why do you think I'd understand, I'm just another animal too.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.2783333333333333,
+    "style": "discouraged",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm doing it again, aren't I?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.15,
+    "style": "frustrated",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Well, aren't you just a ray of sunshine when it comes to relationships!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.30874999999999997,
+    "style": "aggravated",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "Insufficient vigilance is simply inexcusable!",
+    "sentiment": 0.0,
+    "subjectivity": 0.35714285714285715,
+    "word_count": 5,
+    "complexity_score": 0.29000000000000004,
+    "style": "outraged",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "You're just jealous because it listens without judging.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.41,
+    "style": "disturbed",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "I'm worried about you, they're just animals.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.265,
+    "style": "concerned",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "I'm worried about you, let's talk about this.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.2633333333333333,
+    "style": "concerned",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I can't help it, they're my thoughts too.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.21333333333333332,
+    "style": "upset",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "I've heard enough of your constant griping about the bus!",
+    "sentiment": 0.0,
+    "subjectivity": 0.41666666666666663,
+    "word_count": 10,
+    "complexity_score": 0.32166666666666666,
+    "style": "angry",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "You're your own worst critic, yet you still expect applause.",
+    "sentiment": -0.2,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.22576923076923078,
+    "style": "disillusioned",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm so terrible at this, it's almost impressive.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.27166666666666667,
+    "style": "bitter",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Is everything alright with your connection?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.3192857142857143,
+    "style": "concerned",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Despite my complaints, the traffic still seems as endless as ever.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 11,
+    "complexity_score": 0.36423076923076925,
+    "style": "discouraged",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "What's the point of complaining if you're not willing to change your habits?",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 13,
+    "complexity_score": 0.32749999999999996,
+    "style": "impatient",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "I acknowledge your criticism of technological advancements.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.3575,
+    "style": "dispassionate",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I'm tired of being my own worst conversation!",
+    "sentiment": -0.26666666666666666,
+    "subjectivity": 0.9,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "frustrated",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "I swear, I should've just kept renting.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "dissatisfied",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I can't escape my own mind.",
+    "sentiment": 0.6,
+    "subjectivity": 1.0,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "troubled",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "Just another day, same old complaints.",
+    "sentiment": 0.05,
+    "subjectivity": 0.1625,
+    "word_count": 6,
+    "complexity_score": 0.22,
+    "style": "disillusioned",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I've heard that before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.13999999999999999,
+    "style": "displeased",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "I'm fed up, the internet's still down.",
+    "sentiment": -0.15555555555555556,
+    "subjectivity": 0.2888888888888889,
+    "word_count": 7,
+    "complexity_score": 0.20136363636363638,
+    "style": "unhappy",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I wish I didn't care as much.",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.135,
+    "style": "unhappy",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "I wish I could enjoy it like you do.",
+    "sentiment": 0.4,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.18,
+    "style": "unhappy",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I'm tired of hearing your complaints about security, it's not my job to hold your hand!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 16,
+    "complexity_score": 0.39,
+    "style": "angry",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "I've heard it all before, find something new to gripe about.",
+    "sentiment": 0.13636363636363635,
+    "subjectivity": 0.45454545454545453,
+    "word_count": 11,
+    "complexity_score": 0.26,
+    "style": "displeased",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "It's not like my paycheck will listen anyway.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "disillusioned",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "Oh, I'm sorry to inconvenience the trash.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "sarcastic",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "I note your dissatisfaction with social media.",
+    "sentiment": 0.03333333333333333,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 7,
+    "complexity_score": 0.2075,
+    "style": "dispassionate",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "I'd rather listen to your snoring!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "sarcastic",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Impudent! As if you hadn't cast your own vote!",
+    "sentiment": 0.75,
+    "subjectivity": 1.0,
+    "word_count": 9,
+    "complexity_score": 0.1733333333333333,
+    "style": "outraged",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "I swear, if you say 'I don't have time to read' one more time...",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 14,
+    "complexity_score": 0.3007894736842105,
+    "style": "frustrated",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "Oh, please spare me the 'neighborhood' complaint again!",
+    "sentiment": -0.375,
+    "subjectivity": 0.2,
+    "word_count": 8,
+    "complexity_score": 0.23772727272727273,
+    "style": "frustrated",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "Oh, I'd love to help with waste management, but you know what they say, 'Don't throw pearls before swine'.",
+    "sentiment": 0.15,
+    "subjectivity": 0.3,
+    "word_count": 19,
+    "complexity_score": 0.42846153846153845,
+    "style": "ironic",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I guess we wouldn't know how to function without big brother listening.",
+    "sentiment": 0.0,
+    "subjectivity": 0.1,
+    "word_count": 12,
+    "complexity_score": 0.3457142857142857,
+    "style": "disillusioned",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "You're always complaining about real estate, but you never do anything about it!",
+    "sentiment": 0.25,
+    "subjectivity": 0.30000000000000004,
+    "word_count": 13,
+    "complexity_score": 0.32749999999999996,
+    "style": "aggravated",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "Well, isn't that the pot calling the kettle black?",
+    "sentiment": -0.16666666666666666,
+    "subjectivity": 0.43333333333333335,
+    "word_count": 9,
+    "complexity_score": 0.2383333333333333,
+    "style": "annoyed",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "I'm drowning in debt, and no one seems to understand.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "troubled",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "Spare me the sob story, just find someone!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "impatient",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I'm not complaining, I'm simply pointing out that this environment is subpar.",
+    "sentiment": 0.0,
+    "subjectivity": 0.35714285714285715,
+    "word_count": 12,
+    "complexity_score": 0.33375,
+    "style": "dissatisfied",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "And I suppose you'd prefer me to wave a magic wand for the hours and the money, too?",
+    "sentiment": 0.5,
+    "subjectivity": 1.0,
+    "word_count": 18,
+    "complexity_score": 0.34833333333333333,
+    "style": "irritated",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "I'm always the first to admit my flaws, but it feels like you're only seeing them.",
+    "sentiment": 0.125,
+    "subjectivity": 0.6666666666666666,
+    "word_count": 16,
+    "complexity_score": 0.315,
+    "style": "upset",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "I notice you often express dissatisfaction regarding your friendships.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.31000000000000005,
+    "style": "dispassionate",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "I must've missed the memo where complaining became a fast track to promotion.",
+    "sentiment": 0.2,
+    "subjectivity": 0.6,
+    "word_count": 13,
+    "complexity_score": 0.2783333333333333,
+    "style": "ironic",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "You're like a broken record, always complaining about those same old goals.",
+    "sentiment": -0.10000000000000002,
+    "subjectivity": 0.2416666666666667,
+    "word_count": 12,
+    "complexity_score": 0.29166666666666663,
+    "style": "annoyed",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "I'm worried about your feelings, you seem quite upset about social media.",
+    "sentiment": 0.03333333333333333,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 12,
+    "complexity_score": 0.3183333333333333,
+    "style": "concerned",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Why do my dreams only ever happen when I'm awake?",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.18,
+    "style": "dismayed",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "But you're the one who posts all those perfect moments, aren't you?",
+    "sentiment": 1.0,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.29,
+    "style": "disturbed",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "I can't believe I didn't appreciate my younger self!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.28,
+    "style": "frustrated",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "I'm tired of paying so much for subpar care.",
+    "sentiment": -0.1,
+    "subjectivity": 0.44999999999999996,
+    "word_count": 9,
+    "complexity_score": 0.21954545454545454,
+    "style": "dissatisfied",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "Well, I suppose there's always something to grumble about.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.28,
+    "style": "disappointed",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "I've noted your concerns regarding the necessary home repairs.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 9,
+    "complexity_score": 0.3104545454545455,
+    "style": "dispassionate",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "I suppose I'll just write off your complaining as a tax deduction.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3171428571428571,
+    "style": "bitter",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Oh, here we go again with the endless commute complaints!",
+    "sentiment": -0.15625,
+    "subjectivity": 0.75,
+    "word_count": 10,
+    "complexity_score": 0.30500000000000005,
+    "style": "annoyed",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "I'm not a plant, I don't grow just because you water me with complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.3477777777777778,
+    "style": "frustrated",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "dissatisfied",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I worry that I'm too hard on myself.",
+    "sentiment": -0.2916666666666667,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 8,
+    "complexity_score": 0.21,
+    "style": "worried",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Oh, I'm sorry my subconscious isn't entertaining you enough!",
+    "sentiment": 0.0,
+    "subjectivity": 0.6875,
+    "word_count": 9,
+    "complexity_score": 0.25653846153846155,
+    "style": "irritated",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "And?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 1,
+    "complexity_score": 0.03,
+    "style": "impatient",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "It's always 'they should've done this' or 'why didn't they do that,' yet you haven't made a single frame yourself.",
+    "sentiment": -0.07142857142857142,
+    "subjectivity": 0.21428571428571427,
+    "word_count": 20,
+    "complexity_score": 0.4342857142857143,
+    "style": "disillusioned",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "I've heard enough complaints, just do your job!",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 8,
+    "complexity_score": 0.20136363636363638,
+    "style": "angry",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "I've heard that excuse before, try harder.",
+    "sentiment": -0.07500000000000001,
+    "subjectivity": 0.025,
+    "word_count": 7,
+    "complexity_score": 0.21,
+    "style": "dismissive",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "Oh, aren't we all supposed to care?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "dismissive",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I'm always here, but it seems you're only there when it's convenient.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.2785294117647059,
+    "style": "resentful",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "I guess you'd rather have the responsibility than the freedom, huh?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.28857142857142853,
+    "style": "resentful",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "irritated",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "You perceive smartphones as a source of grievance.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.33499999999999996,
+    "style": "dispassionate",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "I'd love to hear your thoughts on cave paintings too.",
+    "sentiment": 0.5,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.27166666666666667,
+    "style": "sarcastic",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about your feelings.",
+    "response": "I'm here if you'd like to talk about how you're feeling.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.29166666666666663,
+    "style": "concerned",
+    "topic": "your feelings"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "Oh, TV again?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "bored",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "Oh, yes, the roommate saga continues...",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.22388888888888892,
+    "style": "bored",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "I'm my own worst critic, aren't I?",
+    "sentiment": -0.2,
+    "subjectivity": 1.0,
+    "word_count": 7,
+    "complexity_score": 0.165,
+    "style": "disturbed",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, you too?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "disillusioned",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "Despite my efforts, you seem unsatisfied.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.3075,
+    "style": "dissatisfied",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "How dare you complain about career growth when others are just trying to find steady employment!",
+    "sentiment": 0.20833333333333331,
+    "subjectivity": 0.5,
+    "word_count": 16,
+    "complexity_score": 0.3197058823529412,
+    "style": "outraged",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "I'm drowning in this workload, no one understands!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.3013636363636364,
+    "style": "distressed",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "Oh, spare me the tales of your woes!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "dismayed",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "You still insist on complaining about social media?",
+    "sentiment": 0.03333333333333333,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 8,
+    "complexity_score": 0.2461111111111111,
+    "style": "disappointed",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "Oh, poor you.",
+    "sentiment": -0.4,
+    "subjectivity": 0.6,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "dismissive",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "Oh, please, you're complaining about winning the lottery!",
+    "sentiment": 0.625,
+    "subjectivity": 0.75,
+    "word_count": 8,
+    "complexity_score": 0.30500000000000005,
+    "style": "exasperated",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "You have the audacity to complain about mental health when you've never truly struggled?",
+    "sentiment": -0.1,
+    "subjectivity": 0.2,
+    "word_count": 14,
+    "complexity_score": 0.33375,
+    "style": "resentful",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "I suppose you'd prefer it if I did all the shopping myself?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.28857142857142853,
+    "style": "displeased",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Here we go again, it's always something with you.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2383333333333333,
+    "style": "annoyed",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "Well, I never heard you complaining when they were here!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.21333333333333332,
+    "style": "angry",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "I recycled and it ended up in the trash anyway.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.22863636363636367,
+    "style": "dissatisfied",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm such a perfect parent, it's exhausting.",
+    "sentiment": 0.19999999999999998,
+    "subjectivity": 0.6666666666666666,
+    "word_count": 7,
+    "complexity_score": 0.23772727272727273,
+    "style": "sarcastic",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "You're always complaining about TV!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.205,
+    "style": "upset",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "I'll pretend I didn't hear that.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.17944444444444446,
+    "style": "dismissive",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "Oh no, not again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "distressed",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "I'm sorry to hear that you're struggling with your rental situation.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 11,
+    "complexity_score": 0.31,
+    "style": "concerned",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "Spare me the tiresome healthcare woes.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 6,
+    "complexity_score": 0.21928571428571428,
+    "style": "dismissive",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "Oh, you'd rather they work for pennies? That's rich.",
+    "sentiment": 0.375,
+    "subjectivity": 0.75,
+    "word_count": 9,
+    "complexity_score": 0.155,
+    "style": "bitter",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "Oh, spare me your whines while creatures roam free!",
+    "sentiment": 0.5,
+    "subjectivity": 0.8,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "disturbed",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I'm tired of constantly worrying about my privacy being invaded.",
+    "sentiment": -0.2,
+    "subjectivity": 0.5166666666666666,
+    "word_count": 10,
+    "complexity_score": 0.36333333333333334,
+    "style": "unhappy",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "I note your concern regarding work-life balance.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.32,
+    "style": "dispassionate",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Oh, you have dreams too?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "upset",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "Oh, here we go again with the 'work-life balance' lecture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.31038461538461537,
+    "style": "annoyed",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "I'm tired of hearing about your pet peeves!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 8,
+    "complexity_score": 0.25,
+    "style": "frustrated",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "It's not like I can control the rain, you know!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.24884615384615386,
+    "style": "irritated",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Just make new ones.",
+    "sentiment": 0.13636363636363635,
+    "subjectivity": 0.45454545454545453,
+    "word_count": 4,
+    "complexity_score": 0.075,
+    "style": "impatient",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Oh, please don't tell me you didn't like the movie too!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.24499999999999997,
+    "style": "worried",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "You're always so melodramatic.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.15666666666666668,
+    "style": "unhappy",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "Oh, you mean like how my coworkers complain about me?",
+    "sentiment": -0.3125,
+    "subjectivity": 0.6875,
+    "word_count": 10,
+    "complexity_score": 0.29666666666666663,
+    "style": "sarcastic",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "I worry that your complaints might go unnoticed.",
+    "sentiment": -0.2,
+    "subjectivity": 0.6,
+    "word_count": 8,
+    "complexity_score": 0.25722222222222224,
+    "style": "worried",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "Oh, here we go again with the 'work-life balance' lecture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.31038461538461537,
+    "style": "annoyed",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "I can't believe you're complaining about them too!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.265,
+    "style": "upset",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "Your constant complaints about wildlife are beginning to irritate me.",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 10,
+    "complexity_score": 0.3740909090909091,
+    "style": "displeased",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I'm not your friend, I'm just the echo of your complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.27166666666666667,
+    "style": "disturbed",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "I'm tired of my paycheck barely covering my bills.",
+    "sentiment": -0.17500000000000002,
+    "subjectivity": 0.39999999999999997,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "disillusioned",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I'm here to listen if you'd like to talk more about that.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.26499999999999996,
+    "style": "concerned",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "Here we go again, moaning about the office!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "frustrated",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "I'd love to help, but I have all the time in the world.",
+    "sentiment": 0.5,
+    "subjectivity": 0.6,
+    "word_count": 13,
+    "complexity_score": 0.25875,
+    "style": "ironic",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "Here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.075,
+    "style": "fed up",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "Oh, I hope we're not lost again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.15,
+    "style": "worried",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I've recycled my soda can three times this week and you're still lecturing me about saving the planet?!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 18,
+    "complexity_score": 0.21500000000000002,
+    "style": "frustrated",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "You're like the world's most picky critic.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 7,
+    "complexity_score": 0.18,
+    "style": "irritated",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "I swear, if you say 'I don't like this' one more time, I'm ordering pizza!",
+    "sentiment": 0.625,
+    "subjectivity": 0.5,
+    "word_count": 15,
+    "complexity_score": 0.3618181818181818,
+    "style": "aggravated",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "Oh, here we go again with the book grievances.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "dismissive",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I'm tired of hearing myself complain about being a bad friend!",
+    "sentiment": -0.6375,
+    "subjectivity": 0.6833333333333333,
+    "word_count": 11,
+    "complexity_score": 0.3026923076923077,
+    "style": "frustrated",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "I'd rather not eat at all.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.1575,
+    "style": "unhappy",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I wish I could silence this constant inner chatter.",
+    "sentiment": 0.0,
+    "subjectivity": 0.25,
+    "word_count": 9,
+    "complexity_score": 0.27,
+    "style": "discouraged",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "I've heard it all before, haven't I?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.1922727272727273,
+    "style": "frustrated",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "I've heard it all before, just tell me what you want to do about it!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.30333333333333334,
+    "style": "frustrated",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I'm my own worst critic.",
+    "sentiment": -0.2,
+    "subjectivity": 1.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "discouraged",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Oh, you must be new here.",
+    "sentiment": 0.13636363636363635,
+    "subjectivity": 0.45454545454545453,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "ironic",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "Oh, you're just another whiner who can't hack it in the real world!",
+    "sentiment": 0.25,
+    "subjectivity": 0.30000000000000004,
+    "word_count": 13,
+    "complexity_score": 0.2961764705882353,
+    "style": "disturbed",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I suppose I should expect no less.",
+    "sentiment": 0.08333333333333333,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 7,
+    "complexity_score": 0.16999999999999998,
+    "style": "displeased",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "You're acting like we're made of money!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.21,
+    "style": "aggravated",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "You're like a broken thermometer, always complaining about the weather!",
+    "sentiment": -0.5,
+    "subjectivity": 0.4,
+    "word_count": 10,
+    "complexity_score": 0.3334615384615385,
+    "style": "aggravated",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "I find shopping disagreeable.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.23500000000000004,
+    "style": "dispassionate",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "Oh, you again?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "disappointed",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about your feelings.",
+    "response": "Oh, I do love to whine about my emotions, doesn't everyone?",
+    "sentiment": 0.5,
+    "subjectivity": 0.6,
+    "word_count": 11,
+    "complexity_score": 0.29833333333333334,
+    "style": "bitter",
+    "topic": "your feelings"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "It's not my fault you forgot to rinse!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "frustrated",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "What's your point?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "impatient",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "I'm tired of hearing you moan about how great your life is!",
+    "sentiment": 0.3,
+    "subjectivity": 0.725,
+    "word_count": 12,
+    "complexity_score": 0.2814285714285714,
+    "style": "angry",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "Spare me the drama.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.075,
+    "style": "dismissive",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "displeased",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "I hear you, but do you want to swap jobs for the day?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.24499999999999997,
+    "style": "fed up",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "Wishing I could just catch a break like some others seem to.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.24884615384615386,
+    "style": "discouraged",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "You're just jealous you can't keep up!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "angry",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Oh, here we go again with the movie critiques!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "upset",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, the struggle is real... just like my last three paychecks.",
+    "sentiment": 0.1,
+    "subjectivity": 0.18333333333333335,
+    "word_count": 11,
+    "complexity_score": 0.28857142857142853,
+    "style": "ironic",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "Your complaints are as ugly as your taste in art.",
+    "sentiment": -0.7,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.2559090909090909,
+    "style": "displeased",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I've heard it all before, spare me the 'I'm not cut out for this' lecture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.3626190476190476,
+    "style": "fed up",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm at a loss, I thought I was doing better than this.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.29166666666666663,
+    "style": "dismayed",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "I wish I could change it, but the past is just that - past.",
+    "sentiment": -0.25,
+    "subjectivity": 0.25,
+    "word_count": 14,
+    "complexity_score": 0.25875,
+    "style": "disheartened",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Oh, if only my reality was as exciting.",
+    "sentiment": 0.15,
+    "subjectivity": 0.9,
+    "word_count": 8,
+    "complexity_score": 0.29000000000000004,
+    "style": "dismayed",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "I guess I'm just stuck worrying alone.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.17944444444444446,
+    "style": "discouraged",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Oh, for goodness' sake!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.205,
+    "style": "exasperated",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "I hear your concerns about the workplace culture, and I'm here if you'd like to talk more.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 17,
+    "complexity_score": 0.40071428571428575,
+    "style": "concerned",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "Oh, here we go again with the privacy thing.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "bored",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "I often wish I could hug that lonely, confused kid I once was.",
+    "sentiment": -0.25,
+    "subjectivity": 0.7,
+    "word_count": 13,
+    "complexity_score": 0.25166666666666665,
+    "style": "troubled",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "I hear your concerns, are you alright?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.25722222222222224,
+    "style": "concerned",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "If only you'd stayed home, you wouldn't have anything to gripe about now.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 13,
+    "complexity_score": 0.2961764705882353,
+    "style": "bitter",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "I must be doing something right, I've been stuck in the same position for years!",
+    "sentiment": 0.14285714285714285,
+    "subjectivity": 0.33035714285714285,
+    "word_count": 15,
+    "complexity_score": 0.3477777777777778,
+    "style": "ironic",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "I can't believe you're complaining about saving the planet!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.27166666666666667,
+    "style": "outraged",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "Next time, try raising them yourself.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.22,
+    "style": "dismissive",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about your feelings.",
+    "response": "I'm sick of you whining about how you feel!",
+    "sentiment": -0.8928571428571429,
+    "subjectivity": 0.8571428571428571,
+    "word_count": 9,
+    "complexity_score": 0.2559090909090909,
+    "style": "angry",
+    "topic": "your feelings"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "Oh, I love wasting hours at the airport just for the joy of being herded like cattle!",
+    "sentiment": 0.75,
+    "subjectivity": 0.4,
+    "word_count": 17,
+    "complexity_score": 0.3902631578947368,
+    "style": "sarcastic",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "Your walls echo with their laughter, don't they?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22863636363636367,
+    "style": "disturbed",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "How dare you criticize the very thing meant to bring us joy!",
+    "sentiment": 0.6,
+    "subjectivity": 0.25,
+    "word_count": 12,
+    "complexity_score": 0.22576923076923078,
+    "style": "outraged",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "It seems all you do is whine about what's not even real.",
+    "sentiment": 0.2,
+    "subjectivity": 0.30000000000000004,
+    "word_count": 12,
+    "complexity_score": 0.23142857142857143,
+    "style": "displeased",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "You're always so hard on yourself, aren't you?",
+    "sentiment": -0.2916666666666667,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 8,
+    "complexity_score": 0.2383333333333333,
+    "style": "bored",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "Oh, don't we all?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.105,
+    "style": "resentful",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "I worry that you're finding it hard to connect.",
+    "sentiment": -0.2916666666666667,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "concerned",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "I observe that you frequently express dissatisfaction regarding animals.",
+    "sentiment": 0.1,
+    "subjectivity": 0.3,
+    "word_count": 9,
+    "complexity_score": 0.42000000000000004,
+    "style": "dispassionate",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "Oh, you're complaining about events again?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2127777777777778,
+    "style": "dismayed",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I've had it up to here with your environmental complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.27166666666666667,
+    "style": "outraged",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "It's not like anyone cares, anyway.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.16833333333333333,
+    "style": "discouraged",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "Despite my best efforts, I remain a perpetual disappointment to myself professionally.",
+    "sentiment": 0.16666666666666666,
+    "subjectivity": 0.26666666666666666,
+    "word_count": 12,
+    "complexity_score": 0.3742857142857143,
+    "style": "disillusioned",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "I recycle just like you asked, but now I've run out of room for my trash!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 16,
+    "complexity_score": 0.36921052631578943,
+    "style": "upset",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Oh, I wish they'd just set themselves!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "dismayed",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "Oh, here we go again with the book complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "annoyed",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "I'm sorry to hear you're struggling with the weather.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 9,
+    "complexity_score": 0.27166666666666667,
+    "style": "concerned",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "Oh, please, you can't even handle today!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.165,
+    "style": "exasperated",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about your life.",
+    "response": "sigh Oh, look who's found another pebble in their shoe today",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.24884615384615386,
+    "style": "bored",
+    "topic": "your life"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "I recycle faithfully, yet the city's collection has been inconsistent lately.",
+    "sentiment": -0.3,
+    "subjectivity": 0.6,
+    "word_count": 11,
+    "complexity_score": 0.3242857142857143,
+    "style": "troubled",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "Oh, please don't remind me of the endless scroll!",
+    "sentiment": -0.15625,
+    "subjectivity": 0.75,
+    "word_count": 9,
+    "complexity_score": 0.2383333333333333,
+    "style": "distressed",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "It's just insurance, get over it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2127777777777778,
+    "style": "dismissive",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "I can't believe you're whining about legalities again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.3013636363636364,
+    "style": "upset",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "Spare me the whining, just figure it out.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "impatient",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "Oh, you're always so hard on yourself.",
+    "sentiment": -0.2916666666666667,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "dismayed",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "You're just adding to the toxic atmosphere you claim to hate!",
+    "sentiment": -1.0,
+    "subjectivity": 0.9,
+    "word_count": 11,
+    "complexity_score": 0.22576923076923078,
+    "style": "angry",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I worry that your complaints will fall on deaf ears.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2559090909090909,
+    "style": "worried",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "Oh, you're not entertained? Here I go juggling chainsaws for your amusement!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.23875,
+    "style": "frustrated",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "I wish things were different.",
+    "sentiment": 0.0,
+    "subjectivity": 0.6,
+    "word_count": 5,
+    "complexity_score": 0.15666666666666668,
+    "style": "disheartened",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "It's not the commute that bothers me, it's your constant complaining about it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 13,
+    "complexity_score": 0.36676470588235294,
+    "style": "dissatisfied",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, I wish everyone had it as tough as you.",
+    "sentiment": -0.3888888888888889,
+    "subjectivity": 0.8333333333333334,
+    "word_count": 10,
+    "complexity_score": 0.2383333333333333,
+    "style": "ironic",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "I'm worried about how much you seem to be struggling with self-doubt, sweetheart.",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 13,
+    "complexity_score": 0.37749999999999995,
+    "style": "concerned",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "Technology's not perfect? Well, maybe you should've tried being born 50 years earlier!",
+    "sentiment": -0.25,
+    "subjectivity": 0.75,
+    "word_count": 13,
+    "complexity_score": 0.20166666666666666,
+    "style": "disturbed",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "I worry that you might not have access to the internet.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.2383333333333333,
+    "style": "worried",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "Oh, spare me the whining!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.16214285714285714,
+    "style": "annoyed",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "I'm stuck reliving my regrets.",
+    "sentiment": -0.1,
+    "subjectivity": 0.2,
+    "word_count": 5,
+    "complexity_score": 0.21928571428571428,
+    "style": "unhappy",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "That's just what we've been doing, isn't it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.195,
+    "style": "disappointed",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Oh, for crying out loud, it's just a momentary lag!",
+    "sentiment": -0.037500000000000006,
+    "subjectivity": 0.7,
+    "word_count": 10,
+    "complexity_score": 0.26,
+    "style": "exasperated",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "You're always complaining about the internet.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2575,
+    "style": "unhappy",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "I've been told I'm not the first parent to struggle with childcare.",
+    "sentiment": 0.25,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 12,
+    "complexity_score": 0.29833333333333334,
+    "style": "discouraged",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "Yet, we can't afford to move.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.135,
+    "style": "disheartened",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "Spare me the sob story.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.09,
+    "style": "dismissive",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "I'm just trying to make sense of our budget, but it feels like I'm the only one who cares.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 19,
+    "complexity_score": 0.3710869565217391,
+    "style": "upset",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "I wish I could just teleport to work.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.17944444444444446,
+    "style": "disheartened",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "You always find fault, never romance.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "dissatisfied",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "I'm tired of waiting, the bus hasn't come for hours.",
+    "sentiment": -0.4,
+    "subjectivity": 0.7,
+    "word_count": 10,
+    "complexity_score": 0.2814285714285714,
+    "style": "troubled",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I can't even with you today!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.1575,
+    "style": "frustrated",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "You're just another noisy leaf, rustling my nerves!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.23772727272727273,
+    "style": "disturbed",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "Oh, the irony.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "disillusioned",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "It's not like I'm choosing to be poor.",
+    "sentiment": -0.4,
+    "subjectivity": 0.6,
+    "word_count": 8,
+    "complexity_score": 0.22863636363636367,
+    "style": "disillusioned",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, here we go again with the small talk!",
+    "sentiment": -0.3125,
+    "subjectivity": 0.4,
+    "word_count": 9,
+    "complexity_score": 0.1922727272727273,
+    "style": "irritated",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "Oh, here we go again with the 'security' lecture!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.27166666666666667,
+    "style": "annoyed",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "Seriously, if you've got something to say, spit it out!",
+    "sentiment": -0.41666666666666663,
+    "subjectivity": 0.6666666666666666,
+    "word_count": 10,
+    "complexity_score": 0.28857142857142853,
+    "style": "aggravated",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I guess I'll just have to sleep with one eye open tonight.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.26,
+    "style": "disappointed",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "I'm sorry, it's just the paperwork is driving me to despair.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 11,
+    "complexity_score": 0.305,
+    "style": "troubled",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "Well, aren't we just a bundle of joy after hours!",
+    "sentiment": 1.0,
+    "subjectivity": 0.2,
+    "word_count": 10,
+    "complexity_score": 0.24115384615384616,
+    "style": "irritated",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm only complaining because I hate seeing others have all the fun.",
+    "sentiment": -0.16666666666666666,
+    "subjectivity": 0.7000000000000001,
+    "word_count": 12,
+    "complexity_score": 0.28857142857142853,
+    "style": "sarcastic",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "I worry your complaints might fall on deaf ears.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22,
+    "style": "worried",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I suppose you'd prefer if they kept their opinions to themselves?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.31038461538461537,
+    "style": "disappointed",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Oh, you too?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "dismayed",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Either watch it or don't, but let's not hear your endless griping!",
+    "sentiment": -0.15625,
+    "subjectivity": 0.75,
+    "word_count": 12,
+    "complexity_score": 0.29,
+    "style": "impatient",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "I've heard better whines.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "dismissive",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "You think you can do better? Then take my place!",
+    "sentiment": 0.625,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.09,
+    "style": "angry",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "Oh, here we go again with the security lecture!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "annoyed",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Well, isn't that just what the popcorn's for?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.2383333333333333,
+    "style": "disillusioned",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "Well, you don't have to like it, just stop whining about it!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.28375,
+    "style": "fed up",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Dreams are my tormentors, awake!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.16214285714285714,
+    "style": "disturbed",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "I suppose I should just grow stagnant like the moss on this rock.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.31,
+    "style": "resentful",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "Oh, here we go again with the book complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "fed up",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "Spare me the lecture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.15500000000000003,
+    "style": "dismissive",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "Oh, so now we're sympathizing with the beasts over my suffering?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.31,
+    "style": "disturbed",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I wouldn't have it any other way.",
+    "sentiment": -0.125,
+    "subjectivity": 0.375,
+    "word_count": 7,
+    "complexity_score": 0.135,
+    "style": "ironic",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about your life.",
+    "response": "I've heard it all before, why don't you just do something about it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.3138235294117647,
+    "style": "frustrated",
+    "topic": "your life"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "Enough already, it's just nature!",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 5,
+    "complexity_score": 0.16999999999999998,
+    "style": "impatient",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "Oh, I'd love to just DIY like the internet says, but who has time for that when I'm busy scheduling Zoom meetings about how many paper clips we've used this month?",
+    "sentiment": 0.3666666666666667,
+    "subjectivity": 0.4666666666666666,
+    "word_count": 31,
+    "complexity_score": 0.6117567567567568,
+    "style": "sarcastic",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "Oh, isn't it just terrible how the world is literally burning around us?",
+    "sentiment": -1.0,
+    "subjectivity": 1.0,
+    "word_count": 13,
+    "complexity_score": 0.33375,
+    "style": "bitter",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I'm surprised you'd complain, given your lax security habits.",
+    "sentiment": 0.1,
+    "subjectivity": 0.9,
+    "word_count": 9,
+    "complexity_score": 0.2873076923076923,
+    "style": "dismayed",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Oh, here we go again with the 'my friends don't understand me' saga.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.3197058823529412,
+    "style": "fed up",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "You'd think we were still using rotary phones!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "exasperated",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "But it's meant to make life easier, isn't it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.195,
+    "style": "troubled",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "I'd love to 'childcare', if only someone cared for me.",
+    "sentiment": 0.25,
+    "subjectivity": 0.8,
+    "word_count": 10,
+    "complexity_score": 0.31,
+    "style": "bitter",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "Oh, you're worried now? Should've seen it coming.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.12826923076923077,
+    "style": "bitter",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "Well, I've been trying to manage my money better, but honestly, it feels like I'm banging my head against a wall.",
+    "sentiment": 0.55,
+    "subjectivity": 0.7,
+    "word_count": 21,
+    "complexity_score": 0.4716666666666667,
+    "style": "discouraged",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "I guess I should've expected this, nothing ever goes smoothly.",
+    "sentiment": 0.15000000000000002,
+    "subjectivity": 0.45,
+    "word_count": 10,
+    "complexity_score": 0.2873076923076923,
+    "style": "disheartened",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "Here we go again, reliving history!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.22,
+    "style": "fed up",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "I'm tired of hearing your constant complaints about the housing market.",
+    "sentiment": -0.2,
+    "subjectivity": 0.5166666666666666,
+    "word_count": 11,
+    "complexity_score": 0.36423076923076925,
+    "style": "displeased",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about your life.",
+    "response": "Well, then change it!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "impatient",
+    "topic": "your life"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "exasperated",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "I'm terrified that I'll never be the partner you deserve.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.31038461538461537,
+    "style": "distressed",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "You always find fault with those who need help.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.18,
+    "style": "upset",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "Oh, you're still harping on about that?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.25,
+    "style": "displeased",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "Your complaints are as exhausting as the journey itself.",
+    "sentiment": -0.4,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.30000000000000004,
+    "style": "displeased",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Well, don't let me hold you back from buying then.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.21807692307692308,
+    "style": "resentful",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Oh, really?",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 2,
+    "complexity_score": 0.06,
+    "style": "upset",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "You always gripe, but never pet.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "resentful",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "Yet here you are, typing your complaint on this very tech.",
+    "sentiment": -0.04999999999999999,
+    "subjectivity": 0.25,
+    "word_count": 11,
+    "complexity_score": 0.24884615384615386,
+    "style": "disillusioned",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I guess I'm just destined to live alone with my plants.",
+    "sentiment": 0.13636363636363635,
+    "subjectivity": 0.5,
+    "word_count": 11,
+    "complexity_score": 0.24884615384615386,
+    "style": "disheartened",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "Oh, you mean like when my mortgage talks back to me?",
+    "sentiment": -0.15625,
+    "subjectivity": 0.34375,
+    "word_count": 11,
+    "complexity_score": 0.24884615384615386,
+    "style": "ironic",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Well, isn't that just peachy.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.12,
+    "style": "displeased",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "You're like a broken record, always harping on about the past!",
+    "sentiment": -0.35625,
+    "subjectivity": 0.325,
+    "word_count": 11,
+    "complexity_score": 0.3028571428571428,
+    "style": "exasperated",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "I'm here to listen if you'd like to talk about what's been troubling you.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.32555555555555554,
+    "style": "concerned",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "I suppose you'd prefer I did it myself.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "resentful",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Oh, you're always saying that.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.1575,
+    "style": "dismissive",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "How dare you complain about dating? It's a privilege!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.18166666666666667,
+    "style": "outraged",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "Oh, here we go again with the 'social media is ruining society' lecture.",
+    "sentiment": 0.03333333333333333,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 13,
+    "complexity_score": 0.35874999999999996,
+    "style": "annoyed",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "It's like complaining about the rain in Seattle.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.32,
+    "style": "disillusioned",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I guess I'm just old-fashioned, expecting a little privacy.",
+    "sentiment": -0.1875,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.28,
+    "style": "disheartened",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "I suppose it's not raining enough to suit you either.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.24666666666666665,
+    "style": "bored",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I wish I could find someone who doesn't cause me constant heartache.",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 12,
+    "complexity_score": 0.2957142857142857,
+    "style": "unhappy",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I've had it up to here with your constant complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 10,
+    "complexity_score": 0.27166666666666667,
+    "style": "angry",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "And?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 1,
+    "complexity_score": 0.03,
+    "style": "impatient",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "Oh, I'm sorry, I didn't realize my brain was on mute today.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.2961764705882353,
+    "style": "ironic",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Don't you dare complain about the commute, I've been walking on coals to get here!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.37973684210526315,
+    "style": "angry",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "Yet, you do nothing to change it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.17944444444444446,
+    "style": "dissatisfied",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "I'm really worried about you, is there anything I can do to help?",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 13,
+    "complexity_score": 0.30874999999999997,
+    "style": "concerned",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "I just wish I could find some common ground with my colleagues.",
+    "sentiment": -0.3,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.24884615384615386,
+    "style": "troubled",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, please, everyone's got problems.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.22388888888888892,
+    "style": "dismissive",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I thought you said we were all adults here.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.19,
+    "style": "disappointed",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "I'm sick of hearing your constant complaints about our workplace culture!",
+    "sentiment": -0.35714285714285715,
+    "subjectivity": 0.5952380952380952,
+    "word_count": 11,
+    "complexity_score": 0.395,
+    "style": "angry",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Oh, because my life wasn't dramatic enough already!",
+    "sentiment": -0.21666666666666667,
+    "subjectivity": 0.55,
+    "word_count": 8,
+    "complexity_score": 0.3013636363636364,
+    "style": "sarcastic",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "Enough already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 2,
+    "complexity_score": 0.17833333333333334,
+    "style": "impatient",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "It seems my concerns fall on deaf ears, another day passes without meaningful action.",
+    "sentiment": 0.3,
+    "subjectivity": 0.3,
+    "word_count": 14,
+    "complexity_score": 0.37749999999999995,
+    "style": "disheartened",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "exasperated",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "Well, don't hold your breath waiting for me to plant trees!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.26,
+    "style": "upset",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "I'm worried your workload might be spiraling out of control.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.36333333333333334,
+    "style": "worried",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "I worry that your complaints might indicate deeper issues at home.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.29666666666666663,
+    "style": "worried",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I'm just trying to cope, but every gathering feels like walking on eggshells.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.3525,
+    "style": "distressed",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "I've read them all, yet still I'm left uninspired.",
+    "sentiment": -0.25,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.22576923076923078,
+    "style": "disheartened",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "I worry about safety, but nobody seems to listen.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.1922727272727273,
+    "style": "disheartened",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Oh, you and every other employee.",
+    "sentiment": -0.125,
+    "subjectivity": 0.375,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "dismissive",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "Your complaints are as useless as my pulse when they found me collapsed!",
+    "sentiment": -0.625,
+    "subjectivity": 0.2,
+    "word_count": 13,
+    "complexity_score": 0.3171428571428571,
+    "style": "disturbed",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "I'm worried about you, what's been happening in your neighborhood?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.3385714285714286,
+    "style": "concerned",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "It's not like they're going to change the system just because you whine.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.3025,
+    "style": "bored",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I feel like I'm constantly letting you down.",
+    "sentiment": -0.07777777777777778,
+    "subjectivity": 0.3111111111111111,
+    "word_count": 8,
+    "complexity_score": 0.26,
+    "style": "unhappy",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "Well, what do you suggest we do then?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "frustrated",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I've heard your complaints, but have you ever considered that I might be listening to yours?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 16,
+    "complexity_score": 0.36394736842105263,
+    "style": "aggravated",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "Oh, I'm sorry for caring about the planet, let me just toss this trash into the ocean instead.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 18,
+    "complexity_score": 0.40272727272727277,
+    "style": "sarcastic",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "I've heard that complaint before.",
+    "sentiment": -0.3,
+    "subjectivity": 0.2,
+    "word_count": 5,
+    "complexity_score": 0.24785714285714283,
+    "style": "dissatisfied",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "Oh, isn't that ironic, coming from you?",
+    "sentiment": 0.2,
+    "subjectivity": 0.9,
+    "word_count": 7,
+    "complexity_score": 0.21954545454545454,
+    "style": "bitter",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "fed up",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "I guess I shouldn't have bothered planning anything.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.27,
+    "style": "disappointed",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "You're always moaning, but have you ever considered that your actions might contribute to this 'friendship failure'?",
+    "sentiment": -0.31666666666666665,
+    "subjectivity": 0.3,
+    "word_count": 17,
+    "complexity_score": 0.44357142857142856,
+    "style": "irritated",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "Oh, really? Let's see you do better then.",
+    "sentiment": 0.35,
+    "subjectivity": 0.35,
+    "word_count": 8,
+    "complexity_score": 0.09,
+    "style": "dismayed",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "Oh, here we go again...",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "dismayed",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "exasperated",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "I'm sure your allergies are just thrilled with that new puppy.",
+    "sentiment": 0.4121212121212121,
+    "subjectivity": 0.681144781144781,
+    "word_count": 11,
+    "complexity_score": 0.2796153846153846,
+    "style": "sarcastic",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "I wish you'd appreciate them.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.16214285714285714,
+    "style": "disappointed",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "Oh, I'd love to hear your plans for world peace too.",
+    "sentiment": 0.5,
+    "subjectivity": 0.6,
+    "word_count": 11,
+    "complexity_score": 0.23142857142857143,
+    "style": "sarcastic",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "I dreamt I was flying, and you complained it wasn't realistic!",
+    "sentiment": -0.04583333333333334,
+    "subjectivity": 0.26666666666666666,
+    "word_count": 11,
+    "complexity_score": 0.2671428571428571,
+    "style": "upset",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "I'm sick of your constant griping about the housing market!",
+    "sentiment": -0.35714285714285715,
+    "subjectivity": 0.5952380952380952,
+    "word_count": 10,
+    "complexity_score": 0.33,
+    "style": "angry",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "Well, maybe if you spent less time complaining and more time working...",
+    "sentiment": 0.07777777777777778,
+    "subjectivity": 0.22222222222222224,
+    "word_count": 12,
+    "complexity_score": 0.28857142857142853,
+    "style": "irritated",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "Well, what are you doing about it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.16833333333333333,
+    "style": "impatient",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "Oh, sure, because the wheel of progress was invented just to make your life harder!",
+    "sentiment": 0.1875,
+    "subjectivity": 0.4444444444444444,
+    "word_count": 15,
+    "complexity_score": 0.37,
+    "style": "sarcastic",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "I'm really concerned that you're not enjoying the music.",
+    "sentiment": -0.024999999999999994,
+    "subjectivity": 0.4,
+    "word_count": 9,
+    "complexity_score": 0.27166666666666667,
+    "style": "worried",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "Yet, no improvement seems to come.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "discouraged",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "It's not like I'm paying for the privilege of living in someone else's stress-induced heart attack.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 16,
+    "complexity_score": 0.42,
+    "style": "disillusioned",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "Just silence them already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.23500000000000004,
+    "style": "impatient",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "I've heard it all before, get on the bus already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.27192307692307693,
+    "style": "fed up",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I hear your concerns, but I've heard it all before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.24884615384615386,
+    "style": "dissatisfied",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "You think you can do better? Then show me!",
+    "sentiment": 0.625,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.0825,
+    "style": "angry",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "Oh, here we go again with the 'smartphones are ruining everything' lecture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3516666666666667,
+    "style": "annoyed",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "Oh, still at it with the roommate complaints, huh?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.29666666666666663,
+    "style": "disappointed",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "How dare you criticize the very air we'll breathe tomorrow!",
+    "sentiment": 0.25,
+    "subjectivity": 0.3,
+    "word_count": 10,
+    "complexity_score": 0.28,
+    "style": "outraged",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "Despite my best efforts, I still feel like I'm falling short.",
+    "sentiment": 0.5,
+    "subjectivity": 0.3,
+    "word_count": 11,
+    "complexity_score": 0.3385714285714286,
+    "style": "unhappy",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "You always whine about your childhood, but I had to deal with you then too.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.3138235294117647,
+    "style": "dissatisfied",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "Oh great, another alarmist lecture.",
+    "sentiment": 0.8,
+    "subjectivity": 0.75,
+    "word_count": 5,
+    "complexity_score": 0.2764285714285714,
+    "style": "annoyed",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "Well, if you don't like it, why don't you just stay single?",
+    "sentiment": -0.07142857142857142,
+    "subjectivity": 0.21428571428571427,
+    "word_count": 12,
+    "complexity_score": 0.2726470588235294,
+    "style": "displeased",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "Oh, here we go again, reliving my past mistakes.",
+    "sentiment": -0.25,
+    "subjectivity": 0.25,
+    "word_count": 9,
+    "complexity_score": 0.24666666666666665,
+    "style": "resentful",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "I'm so tired of hearing about sports.",
+    "sentiment": -0.4,
+    "subjectivity": 0.7,
+    "word_count": 7,
+    "complexity_score": 0.2461111111111111,
+    "style": "disheartened",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Oh, do you want me to add your name to my list too?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.22499999999999998,
+    "style": "exasperated",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "Oh, I'd love to have a life to balance with my work!",
+    "sentiment": 0.625,
+    "subjectivity": 0.6,
+    "word_count": 12,
+    "complexity_score": 0.27166666666666667,
+    "style": "sarcastic",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Oh, here we go again with the endless salary grievances.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 10,
+    "complexity_score": 0.27166666666666667,
+    "style": "resentful",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Oh, not this again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "irritated",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "You're always harping on about privacy, but where was your concern when I needed some?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.37,
+    "style": "resentful",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "I'm sick of your endless complaints about the office environment!",
+    "sentiment": -0.43526785714285715,
+    "subjectivity": 0.8035714285714286,
+    "word_count": 10,
+    "complexity_score": 0.33,
+    "style": "angry",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "I'm just drowning in my problems, and no one seems to care.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.29833333333333334,
+    "style": "unhappy",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "You despairingly wonder, 'Is this the best I can do?'",
+    "sentiment": 1.0,
+    "subjectivity": 0.3,
+    "word_count": 10,
+    "complexity_score": 0.22576923076923078,
+    "style": "dismayed",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "You'd think you were their boss, not just another pair of hands.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.27166666666666667,
+    "style": "bitter",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "And here we go again, with the book complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "irritated",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "I worry that your discontent might spiral into something more.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.2922727272727273,
+    "style": "worried",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Oh, you're just another tenant with a tale of woe.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.27192307692307693,
+    "style": "bitter",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Spare me the rental woes, it's not like you're living in the Taj Mahal.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.30333333333333334,
+    "style": "dismissive",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "Oh, here we go again with the endless self-criticism!",
+    "sentiment": -0.15625,
+    "subjectivity": 0.75,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "frustrated",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "Oh, I'm such a burden to myself.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 7,
+    "complexity_score": 0.15,
+    "style": "dismayed",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "I've heard enough, just book the ticket already.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 8,
+    "complexity_score": 0.20136363636363638,
+    "style": "impatient",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "Yet again, I find myself surrounded by chaos and noise in this open-office setup.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.32749999999999996,
+    "style": "troubled",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "Oh, please, let's just move on from the endless 'poor little me' stories.",
+    "sentiment": -0.23750000000000002,
+    "subjectivity": 0.6166666666666667,
+    "word_count": 13,
+    "complexity_score": 0.3477777777777778,
+    "style": "fed up",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "Oh, how inconsiderate of them to not follow your schedule.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.27166666666666667,
+    "style": "resentful",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "Oh, you're at it again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.1575,
+    "style": "disappointed",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "Oh, you'd know all about saving the world if it weren't for those pesky trees getting in your way.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 19,
+    "complexity_score": 0.4145652173913043,
+    "style": "disillusioned",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Oh, you're just another broken record.",
+    "sentiment": -0.4,
+    "subjectivity": 0.4,
+    "word_count": 6,
+    "complexity_score": 0.17944444444444446,
+    "style": "bitter",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "Oh, you're just having a 'bad day', aren't you?",
+    "sentiment": -0.6999999999999998,
+    "subjectivity": 0.6666666666666666,
+    "word_count": 9,
+    "complexity_score": 0.22499999999999998,
+    "style": "ironic",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "Oh, here we go again with the endless parental critique.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 10,
+    "complexity_score": 0.30500000000000005,
+    "style": "bored",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "Oh, I wish I had less to do!",
+    "sentiment": -0.20833333333333331,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "dismayed",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Politics, you say? I've long since given up expecting anything but chaos.",
+    "sentiment": -0.05,
+    "subjectivity": 0.4,
+    "word_count": 12,
+    "complexity_score": 0.21375,
+    "style": "disillusioned",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "Oh, you must be new here.",
+    "sentiment": 0.13636363636363635,
+    "subjectivity": 0.45454545454545453,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "bitter",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "I've got news for you, the trash doesn't care about your complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3025,
+    "style": "disturbed",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "Oh, not again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "troubled",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "Oh, I do hope my endless complaints about music aren't too much of a downer for you.",
+    "sentiment": 0.037500000000000006,
+    "subjectivity": 0.475,
+    "word_count": 17,
+    "complexity_score": 0.38499999999999995,
+    "style": "sarcastic",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about events.",
+    "response": "Despite my protests, the event remains unchanged.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.34611111111111115,
+    "style": "dissatisfied",
+    "topic": "events"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "I'd rather live under a bridge with trolls than deal with these constant home repairs!",
+    "sentiment": 0.06818181818181818,
+    "subjectivity": 0.41666666666666663,
+    "word_count": 15,
+    "complexity_score": 0.37264705882352944,
+    "style": "disturbed",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "Oh, you're still harping on about that?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.25,
+    "style": "exasperated",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "I was dissatisfied with my childhood self.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.2575,
+    "style": "dispassionate",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "What do you mean, 'complain'? This isn't some trivial grievance!",
+    "sentiment": -0.390625,
+    "subjectivity": 0.6875,
+    "word_count": 10,
+    "complexity_score": 0.1925,
+    "style": "outraged",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm getting tired of your constant whining about your own flaws!",
+    "sentiment": 0.11666666666666665,
+    "subjectivity": 0.6777777777777777,
+    "word_count": 11,
+    "complexity_score": 0.3334615384615385,
+    "style": "frustrated",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I've heard that complaint from you every day this week.",
+    "sentiment": -0.3,
+    "subjectivity": 0.2,
+    "word_count": 10,
+    "complexity_score": 0.2633333333333333,
+    "style": "annoyed",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Oh, I wish I could afford to buy!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "dismayed",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "I'm sorry to hear that you're upset by the weather.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.27192307692307693,
+    "style": "concerned",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "I've had it up to here with your constant complaints about wildlife.",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 12,
+    "complexity_score": 0.3385714285714286,
+    "style": "displeased",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "Oh, here we go again with the animal complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "annoyed",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Oh, for heaven's sake, just wake up!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.1922727272727273,
+    "style": "annoyed",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "I'm tired of books always letting me down.",
+    "sentiment": -0.2777777777777778,
+    "subjectivity": 0.49444444444444446,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "unhappy",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about noise.",
+    "response": "I'm struggling to concentrate, the noise is just too much!",
+    "sentiment": 0.25,
+    "subjectivity": 0.2,
+    "word_count": 10,
+    "complexity_score": 0.25653846153846155,
+    "style": "distressed",
+    "topic": "noise"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "It's not like I'm asking for the moon!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.21954545454545454,
+    "style": "dismayed",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "I hear your frustration, what's been bothering you about the books lately?",
+    "sentiment": -0.3,
+    "subjectivity": 0.6,
+    "word_count": 12,
+    "complexity_score": 0.29833333333333334,
+    "style": "concerned",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "Oh, I'm just so tired of these endless thoughts!",
+    "sentiment": -0.278125,
+    "subjectivity": 0.725,
+    "word_count": 9,
+    "complexity_score": 0.27166666666666667,
+    "style": "distressed",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "I thought you'd be doing more than just complaining.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "disappointed",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Really, again?",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 2,
+    "complexity_score": 0.06,
+    "style": "dismayed",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "I suppose I should be grateful, but it feels like 'wellbeing' is just a word they use to silence complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 20,
+    "complexity_score": 0.44499999999999995,
+    "style": "disheartened",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "Oh, I do hope they invent time travel so you can go back and complain some more!",
+    "sentiment": 0.3125,
+    "subjectivity": 0.25,
+    "word_count": 17,
+    "complexity_score": 0.3218421052631579,
+    "style": "ironic",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "Well, I guess that's what happens when you aim too high.",
+    "sentiment": 0.16,
+    "subjectivity": 0.54,
+    "word_count": 11,
+    "complexity_score": 0.23857142857142857,
+    "style": "fed up",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "I guess I'm just destined to watch endless reruns and reality shows.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 12,
+    "complexity_score": 0.2957142857142857,
+    "style": "discouraged",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "But I thought we were supposed to be moving forward together!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.31333333333333335,
+    "style": "upset",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "Yet another day filled with coworker complaints.",
+    "sentiment": 0.4,
+    "subjectivity": 0.9,
+    "word_count": 7,
+    "complexity_score": 0.3075,
+    "style": "unhappy",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "Oh, you're still harping on about healthcare? Again?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.20666666666666667,
+    "style": "annoyed",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "I suppose I'll just have to keep on scraping by.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.29666666666666663,
+    "style": "discouraged",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I guess it's not like anyone will listen anyway.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.1922727272727273,
+    "style": "discouraged",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about your feelings.",
+    "response": "I'm tired of hearing you whine about how you feel!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 10,
+    "complexity_score": 0.2633333333333333,
+    "style": "aggravated",
+    "topic": "your feelings"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "I'm not complaining, I'm just wondering if this is the same meal they serve to the rats.",
+    "sentiment": 0.0,
+    "subjectivity": 0.125,
+    "word_count": 17,
+    "complexity_score": 0.3673809523809524,
+    "style": "disturbed",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "You're complaining about the future? That's rich!",
+    "sentiment": 0.234375,
+    "subjectivity": 0.4375,
+    "word_count": 7,
+    "complexity_score": 0.14613636363636365,
+    "style": "upset",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I worry the Earth's future may be bleaker than we think.",
+    "sentiment": 0.0,
+    "subjectivity": 0.125,
+    "word_count": 11,
+    "complexity_score": 0.24884615384615386,
+    "style": "worried",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "It's not like I'm working all hours to make your life easier.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.27166666666666667,
+    "style": "resentful",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "I'm not running a hotel for your endless noise complaints.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 10,
+    "complexity_score": 0.30500000000000005,
+    "style": "displeased",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I feel like I'm my own worst critic.",
+    "sentiment": -0.2,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "disheartened",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "Here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.075,
+    "style": "annoyed",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "Well, they'd stop taking so much if I could afford to pay less.",
+    "sentiment": 0.016666666666666677,
+    "subjectivity": 0.13333333333333333,
+    "word_count": 13,
+    "complexity_score": 0.25875,
+    "style": "bitter",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "Your concerns fall on deaf ears.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.205,
+    "style": "dismissive",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I wish you'd stop harping on your own flaws.",
+    "sentiment": 0.6,
+    "subjectivity": 1.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "displeased",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "I'm not here to listen to your endless complaints about career growth.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 12,
+    "complexity_score": 0.28857142857142853,
+    "style": "displeased",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "I'm sick of hearing your constant complaints about money!",
+    "sentiment": -0.35714285714285715,
+    "subjectivity": 0.5952380952380952,
+    "word_count": 9,
+    "complexity_score": 0.32863636363636367,
+    "style": "angry",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "Spare me the sob story, everyone pays their share.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.20136363636363638,
+    "style": "dismissive",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, cry me a river.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "I'd rather walk on hot coals than hear you gripe about the journey again.",
+    "sentiment": 0.25,
+    "subjectivity": 0.8500000000000001,
+    "word_count": 14,
+    "complexity_score": 0.32125000000000004,
+    "style": "disturbed",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "Well, if you'd spend more time working and less time whining, maybe you'd see some progress!",
+    "sentiment": 0.14583333333333334,
+    "subjectivity": 0.2833333333333333,
+    "word_count": 16,
+    "complexity_score": 0.38642857142857145,
+    "style": "aggravated",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I'm genuinely worried about you, what's causing your distress over the environment?",
+    "sentiment": 0.4,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.40249999999999997,
+    "style": "concerned",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "Well, I suppose the water cooler's just a tad too cold today.",
+    "sentiment": -0.6,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.25166666666666665,
+    "style": "disappointed",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Oh, please spare me the political rant today.",
+    "sentiment": 0.0,
+    "subjectivity": 0.1,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "annoyed",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I've heard enough, just fix it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 6,
+    "complexity_score": 0.135,
+    "style": "impatient",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Oh, I'm so sorry for you and your imaginary problems.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "sarcastic",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "I've heard that tune before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.1907142857142857,
+    "style": "annoyed",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "I'll have you know, I'm more than just a pet.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.23142857142857143,
+    "style": "dismissive",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "Tomorrow seems as gloomy as today.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.205,
+    "style": "unhappy",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "Oh, how dare you prosper!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.16214285714285714,
+    "style": "upset",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "I observe that you are expressing concerns regarding your psychological well-being.",
+    "sentiment": 0.0,
+    "subjectivity": 0.1,
+    "word_count": 11,
+    "complexity_score": 0.405,
+    "style": "dispassionate",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "I'm tired of your constant whining about those trivial legal matters!",
+    "sentiment": -0.05000000000000001,
+    "subjectivity": 0.41111111111111104,
+    "word_count": 11,
+    "complexity_score": 0.36423076923076925,
+    "style": "aggravated",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "I thought you loved browsing for bargains!",
+    "sentiment": 0.875,
+    "subjectivity": 0.8,
+    "word_count": 7,
+    "complexity_score": 0.3075,
+    "style": "upset",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "I've heard enough of your endless complaints about travel!",
+    "sentiment": -0.078125,
+    "subjectivity": 0.625,
+    "word_count": 9,
+    "complexity_score": 0.3195454545454545,
+    "style": "angry",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "Well, don't we all have our nightmares?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "annoyed",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I'm not your therapist, you know.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.17944444444444446,
+    "style": "irritated",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "I guess I'm just meant to be entertained by my own misery.",
+    "sentiment": 0.6,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.26,
+    "style": "disheartened",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "I suppose you'd prefer silence and darkness?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.2683333333333333,
+    "style": "displeased",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "But I'm lost without it!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.205,
+    "style": "distressed",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "I wish people would realize I'm not here to discuss the weather.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.2957142857142857,
+    "style": "dissatisfied",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about your life.",
+    "response": "I can't help but worry when you express such discontent.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.24666666666666665,
+    "style": "worried",
+    "topic": "your life"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "You're like a plant that's been watered with salt.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2633333333333333,
+    "style": "bitter",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "I worry you're finding it difficult.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 6,
+    "complexity_score": 0.22,
+    "style": "worried",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "I guess I just don't understand it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.17944444444444446,
+    "style": "discouraged",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about noise.",
+    "response": "I guess I'm just being too sensitive.",
+    "sentiment": 0.1,
+    "subjectivity": 0.9,
+    "word_count": 7,
+    "complexity_score": 0.17944444444444446,
+    "style": "disheartened",
+    "topic": "noise"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "I'm really sorry to hear you're feeling overwhelmed.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.23772727272727273,
+    "style": "concerned",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "Oh, I hope that's not all you do!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.165,
+    "style": "worried",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "Oh, the trials of being a king of your castle.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.22999999999999998,
+    "style": "dismissive",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I'm not complaining, I just think they could do better.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.22576923076923078,
+    "style": "upset",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "I'm just over here trying to make the 'struggle bus' look like a luxury liner.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.32555555555555554,
+    "style": "sarcastic",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "I worry that your complaints might deter us from our planned trip.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3026923076923077,
+    "style": "worried",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "I acknowledge your concern regarding work-life balance.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.37,
+    "style": "dispassionate",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "I can't believe you're doubting your own abilities!",
+    "sentiment": 0.75,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.2740909090909091,
+    "style": "upset",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "I frequently express dissatisfaction with my thought processes.",
+    "sentiment": 0.1,
+    "subjectivity": 0.3,
+    "word_count": 8,
+    "complexity_score": 0.39055555555555554,
+    "style": "dispassionate",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "You're nothing but a broken record!",
+    "sentiment": -0.5,
+    "subjectivity": 0.4,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "angry",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "How dare you lament about that which isn't even here yet!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.21807692307692308,
+    "style": "outraged",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Oh, you're still lamenting over the rental prices?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22863636363636367,
+    "style": "dismayed",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "Oh, you're still working? Lucky you.",
+    "sentiment": 0.3333333333333333,
+    "subjectivity": 0.8333333333333334,
+    "word_count": 6,
+    "complexity_score": 0.115,
+    "style": "bitter",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "You're always whining about how terrible you are, well guess what? It's not helping!",
+    "sentiment": -1.0,
+    "subjectivity": 1.0,
+    "word_count": 14,
+    "complexity_score": 0.22144736842105261,
+    "style": "angry",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "It's like watching a room full of toddlers fighting over who gets the last cookie.",
+    "sentiment": 0.175,
+    "subjectivity": 0.30833333333333335,
+    "word_count": 15,
+    "complexity_score": 0.3785294117647059,
+    "style": "disillusioned",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "I'm so tired of this endless commute, it's slowly draining my soul.",
+    "sentiment": -0.275,
+    "subjectivity": 0.6166666666666666,
+    "word_count": 12,
+    "complexity_score": 0.33375,
+    "style": "troubled",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Guess I'll just keep shouting into the void.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "discouraged",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "I wish they'd learn to keep their complaints to themselves.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.24666666666666665,
+    "style": "disheartened",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "fed up",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "I worry that you're being too hard on your younger self.",
+    "sentiment": -0.14583333333333334,
+    "subjectivity": 0.2708333333333333,
+    "word_count": 11,
+    "complexity_score": 0.27192307692307693,
+    "style": "concerned",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Oh, you're already complaining about achieving them?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.30000000000000004,
+    "style": "dismayed",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about your thoughts.",
+    "response": "Thoughts, complaints - it's all just echoes in this empty chamber.",
+    "sentiment": -0.1,
+    "subjectivity": 0.5,
+    "word_count": 11,
+    "complexity_score": 0.3171428571428571,
+    "style": "disillusioned",
+    "topic": "your thoughts"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "Oh, here we go again with the roommate complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "frustrated",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I note your dissatisfaction with relationships.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2621428571428571,
+    "style": "dispassionate",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "Oh, the irony of complaining on... social media.",
+    "sentiment": 0.03333333333333333,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 8,
+    "complexity_score": 0.2559090909090909,
+    "style": "bitter",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "How dare you trivialise the law by calling these mere 'issues'!",
+    "sentiment": -0.625,
+    "subjectivity": 0.5,
+    "word_count": 11,
+    "complexity_score": 0.31038461538461537,
+    "style": "outraged",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "You're always complaining about your so-called 'friends'!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.30000000000000004,
+    "style": "aggravated",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "I'm here if you'd like to talk about it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22999999999999998,
+    "style": "concerned",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "I suppose you'd prefer renting indefinitely.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.27,
+    "style": "displeased",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "Oh, here we go again with the money talk.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.1922727272727273,
+    "style": "disappointed",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "Here we go again, another complaint about social media.",
+    "sentiment": -0.13333333333333333,
+    "subjectivity": 0.13333333333333333,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "displeased",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "Oh, the struggle is real...for everyone else.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.265,
+    "style": "ironic",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "I find your critique less than inspiring, artist.",
+    "sentiment": 0.16666666666666669,
+    "subjectivity": 0.5333333333333333,
+    "word_count": 8,
+    "complexity_score": 0.26,
+    "style": "displeased",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "Oh, here we go again with the animal complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "annoyed",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "I've heard that 'real estate's tough' complaint more times than I can count properties.",
+    "sentiment": 0.002777777777777782,
+    "subjectivity": 0.4583333333333333,
+    "word_count": 14,
+    "complexity_score": 0.3477777777777778,
+    "style": "irritated",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "I'm worried about you, how can I help?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22863636363636367,
+    "style": "concerned",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "I'm sick of hearing your complaints about my pets!",
+    "sentiment": -0.8928571428571429,
+    "subjectivity": 0.8571428571428571,
+    "word_count": 9,
+    "complexity_score": 0.2922727272727273,
+    "style": "angry",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "I'd rather walk barefoot on hot coals than endure another shopping trip!",
+    "sentiment": 0.3125,
+    "subjectivity": 0.8500000000000001,
+    "word_count": 12,
+    "complexity_score": 0.3385714285714286,
+    "style": "disturbed",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "Oh, I love getting paid for all this leisure time!",
+    "sentiment": 0.625,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.27166666666666667,
+    "style": "ironic",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "It feels like I've traded my freedom for endless maintenance and bills.",
+    "sentiment": -0.125,
+    "subjectivity": 0.75,
+    "word_count": 12,
+    "complexity_score": 0.3385714285714286,
+    "style": "unhappy",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "Your complaints about waste management fall on deaf ears.",
+    "sentiment": -0.2,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.29000000000000004,
+    "style": "displeased",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "I've heard it all before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.14785714285714285,
+    "style": "fed up",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "I worry they might stop being your friend.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.135,
+    "style": "worried",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "It seems everyone's an expert until it's their own mind whispering 'not today'.",
+    "sentiment": 0.6,
+    "subjectivity": 1.0,
+    "word_count": 13,
+    "complexity_score": 0.3197058823529412,
+    "style": "disillusioned",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I'm worried, you seem really troubled by these environmental problems.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.34115384615384614,
+    "style": "concerned",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "I suppose you'd rather everyone just pull themselves up by their bootstraps.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3457142857142857,
+    "style": "disappointed",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "I suppose if I had your problems, I'd be complaining too.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.3171428571428571,
+    "style": "disillusioned",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Yawn, we're all struggling here, aren't we?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.21333333333333332,
+    "style": "bored",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "You always find something to gripe about, even when things go right!",
+    "sentiment": 0.3571428571428571,
+    "subjectivity": 0.5357142857142857,
+    "word_count": 12,
+    "complexity_score": 0.26,
+    "style": "aggravated",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "I worry that our limited childcare options might cause long-term challenges for us.",
+    "sentiment": -0.07142857142857142,
+    "subjectivity": 0.14285714285714285,
+    "word_count": 13,
+    "complexity_score": 0.39571428571428574,
+    "style": "worried",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "I note your concern regarding mental health.",
+    "sentiment": -0.1,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "dispassionate",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Really, you're complaining about our furry family members?",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 8,
+    "complexity_score": 0.265,
+    "style": "upset",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about your relationships.",
+    "response": "Here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.075,
+    "style": "fed up",
+    "topic": "your relationships"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I'll only stop complaining when the world stops burning.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 9,
+    "complexity_score": 0.23772727272727273,
+    "style": "bitter",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "I acknowledge that you are experiencing difficulties.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.3075,
+    "style": "dispassionate",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "It's always the same, isn't it? Complaining about books never changes them.",
+    "sentiment": 0.0,
+    "subjectivity": 0.125,
+    "word_count": 12,
+    "complexity_score": 0.19220588235294117,
+    "style": "disillusioned",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm just not cut out for this.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.16833333333333333,
+    "style": "distressed",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I can't help but worry that I'm too hard on myself.",
+    "sentiment": -0.2916666666666667,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 11,
+    "complexity_score": 0.25285714285714284,
+    "style": "worried",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "I'm sorry to hear you're struggling, what seems to be the issue?",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.265,
+    "style": "concerned",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "Oh, here we go again, another 'pity party' for one.",
+    "sentiment": -0.1,
+    "subjectivity": 0.2,
+    "word_count": 10,
+    "complexity_score": 0.26,
+    "style": "irritated",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "Well, why don't you just go live there then?",
+    "sentiment": 0.13636363636363635,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.18,
+    "style": "irritated",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about dating.",
+    "response": "Oh, you're just saying that because you have no dates to complain about.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.34624999999999995,
+    "style": "ironic",
+    "topic": "dating"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "I'm worried about your financial situation.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.3075,
+    "style": "concerned",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about your life.",
+    "response": "I'm beginning to think my existence is just one long, pointless complaint...",
+    "sentiment": -0.19999999999999998,
+    "subjectivity": 0.3666666666666667,
+    "word_count": 12,
+    "complexity_score": 0.33166666666666667,
+    "style": "disturbed",
+    "topic": "your life"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I'm just tryna breathe!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.15666666666666668,
+    "style": "disturbed",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "But I'm the one stuck fixing them!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.135,
+    "style": "upset",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "You have mentioned dissatisfaction regarding the meal provided.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.3127777777777778,
+    "style": "dispassionate",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "I note your dissatisfaction regarding the taxation system.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.2683333333333333,
+    "style": "dispassionate",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "How dare you belittle my triumphs!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.21928571428571428,
+    "style": "outraged",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I've heard your privacy concerns, yet you're the one sharing posts publicly!",
+    "sentiment": 0.0,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 12,
+    "complexity_score": 0.33999999999999997,
+    "style": "aggravated",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "I swear, if you complain about sports one more time...",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.2633333333333333,
+    "style": "aggravated",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "I suppose if you'd like to wait longer, we could always add more paperwork.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 14,
+    "complexity_score": 0.3197058823529412,
+    "style": "ironic",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "You're always complaining about your friends!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2575,
+    "style": "aggravated",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "You're practically the world's foremost expert on your own inadequacies.",
+    "sentiment": 0.6,
+    "subjectivity": 1.0,
+    "word_count": 10,
+    "complexity_score": 0.31038461538461537,
+    "style": "sarcastic",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Well, if you'd just make the movies I want to watch, I wouldn't have to!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.315,
+    "style": "frustrated",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "Oh, here we go again with the 'career growth' complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "annoyed",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "I'm just tired of constantly fighting against the tide.",
+    "sentiment": -0.2,
+    "subjectivity": 0.5166666666666666,
+    "word_count": 9,
+    "complexity_score": 0.32863636363636367,
+    "style": "troubled",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, really? Well, have you ever tried being me?",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 9,
+    "complexity_score": 0.0975,
+    "style": "disturbed",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "Meanwhile, the polar bears have started using tiny umbrellas.",
+    "sentiment": -0.041666666666666664,
+    "subjectivity": 0.375,
+    "word_count": 9,
+    "complexity_score": 0.2740909090909091,
+    "style": "bitter",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "bored",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "When will you finally learn to adapt?",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 7,
+    "complexity_score": 0.16999999999999998,
+    "style": "impatient",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "Oh, you're just bragging again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.16999999999999998,
+    "style": "disappointed",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "I suppose I should expect nothing less from you, considering your notorious miserliness.",
+    "sentiment": -0.16666666666666666,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 13,
+    "complexity_score": 0.3783333333333333,
+    "style": "displeased",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "I'm sure they'd love to hear your whining, too.",
+    "sentiment": 0.5,
+    "subjectivity": 0.7444444444444445,
+    "word_count": 9,
+    "complexity_score": 0.22576923076923078,
+    "style": "bitter",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about salary.",
+    "response": "I'm sorry to hear that you're feeling underpaid.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.265,
+    "style": "concerned",
+    "topic": "salary"
+  },
+  {
+    "instruction": "You complain about your feelings.",
+    "response": "I'm tired of your endless complaints about your feelings.",
+    "sentiment": -0.2625,
+    "subjectivity": 0.725,
+    "word_count": 9,
+    "complexity_score": 0.32863636363636367,
+    "style": "displeased",
+    "topic": "your feelings"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "I swear, if you say 'I could do that' one more time...",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.25875,
+    "style": "annoyed",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "Well, I didn't ask for your commentary on my life.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.27192307692307693,
+    "style": "irritated",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "I'm at my wits' end, they're keeping me up all night again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3138235294117647,
+    "style": "troubled",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "I worry that our coverage might not be enough.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.22,
+    "style": "worried",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "Yet you're breathing it, aren't you?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.19,
+    "style": "disturbed",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I guess if you'd just plant a few trees, eh?",
+    "sentiment": -0.2,
+    "subjectivity": 0.1,
+    "word_count": 10,
+    "complexity_score": 0.21807692307692308,
+    "style": "bored",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about books.",
+    "response": "You always did love the taste of ink.",
+    "sentiment": 0.5,
+    "subjectivity": 0.6,
+    "word_count": 8,
+    "complexity_score": 0.16833333333333333,
+    "style": "disappointed",
+    "topic": "books"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "Oh, I wish I could afford to fix up my place!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.195,
+    "style": "distressed",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "I've heard that 'reduce, reuse, recycle' spiel since kindergarten!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.3385714285714286,
+    "style": "fed up",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "How dare you!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.06,
+    "style": "outraged",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "I guess I should've read the reviews before accepting this job.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.2796153846153846,
+    "style": "disappointed",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "I'm sorry to hear that you're struggling, how can I support you today?",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 13,
+    "complexity_score": 0.3197058823529412,
+    "style": "concerned",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "Oh, please, not this again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.12,
+    "style": "annoyed",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "I can't believe you're complaining about something as vital as waste management!",
+    "sentiment": -0.075,
+    "subjectivity": 0.2,
+    "word_count": 12,
+    "complexity_score": 0.3516666666666667,
+    "style": "upset",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "I'm tired of hearing you complain about every little thing!",
+    "sentiment": -0.3171875,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.29666666666666663,
+    "style": "aggravated",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "I suppose you preferred when we all had landlines.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.27,
+    "style": "resentful",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm doing the best I can, isn't that enough?",
+    "sentiment": 0.5,
+    "subjectivity": 0.4,
+    "word_count": 9,
+    "complexity_score": 0.21807692307692308,
+    "style": "annoyed",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I'm worried about your privacy concerns.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.3075,
+    "style": "concerned",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "But it seems no one cares enough to change.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.15,
+    "style": "disheartened",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Your constant complaints are making me worry that you'll never reach them.",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 12,
+    "complexity_score": 0.28857142857142853,
+    "style": "worried",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "Oh, don't I wish I had the luxury of complaining about something that exists!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.3373529411764706,
+    "style": "dismayed",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, spare me the sob story.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.12,
+    "style": "resentful",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "I observe that you are expressing dissatisfaction regarding the surroundings.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.3740909090909091,
+    "style": "dispassionate",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "I'm lost and have no idea how to get back!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.18,
+    "style": "distressed",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "Just appreciate it or don't, but spare me the commentary.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.25653846153846155,
+    "style": "impatient",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "I suppose I should thank you for your charitable contributions while you're at it.",
+    "sentiment": 0.6,
+    "subjectivity": 0.8,
+    "word_count": 14,
+    "complexity_score": 0.37124999999999997,
+    "style": "resentful",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm sorry to hear you're feeling this way, let's talk about it.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 12,
+    "complexity_score": 0.2961764705882353,
+    "style": "concerned",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "Oh, here we go again with the endless complaints about entertainment!",
+    "sentiment": -0.15625,
+    "subjectivity": 0.75,
+    "word_count": 11,
+    "complexity_score": 0.3334615384615385,
+    "style": "exasperated",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "Why must you constantly remind me of my past shortcomings?",
+    "sentiment": -0.125,
+    "subjectivity": 0.29166666666666663,
+    "word_count": 10,
+    "complexity_score": 0.265,
+    "style": "resentful",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about environment.",
+    "response": "Just fix it already!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.15500000000000003,
+    "style": "impatient",
+    "topic": "environment"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "I suppose I'm just meant to suffer in silence, then?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "dismayed",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "irritated",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "Oh, please, you're like a broken record!",
+    "sentiment": -0.5,
+    "subjectivity": 0.4,
+    "word_count": 7,
+    "complexity_score": 0.1922727272727273,
+    "style": "exasperated",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about waste management.",
+    "response": "Oh, I suppose you'd prefer it if we just threw everything into a great big dumpster fire!",
+    "sentiment": 0.4,
+    "subjectivity": 0.425,
+    "word_count": 17,
+    "complexity_score": 0.39,
+    "style": "irritated",
+    "topic": "waste management"
+  },
+  {
+    "instruction": "You complain about noise.",
+    "response": "Oh, you too can have the joy of listening to my symphony of sleepless nights.",
+    "sentiment": 0.8,
+    "subjectivity": 0.2,
+    "word_count": 15,
+    "complexity_score": 0.3608823529411765,
+    "style": "bitter",
+    "topic": "noise"
+  },
+  {
+    "instruction": "You complain about wildlife.",
+    "response": "I note your concern regarding wildlife.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2764285714285714,
+    "style": "dispassionate",
+    "topic": "wildlife"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "I've been waiting for this bus for an hour now, and it's still not here.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.3376315789473684,
+    "style": "troubled",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "It's always something, isn't it? The weather!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.15666666666666668,
+    "style": "frustrated",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "I'm desperate, I just need some help!",
+    "sentiment": -0.75,
+    "subjectivity": 1.0,
+    "word_count": 7,
+    "complexity_score": 0.19,
+    "style": "distressed",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "Well, manage your own expectations then.",
+    "sentiment": 0.6,
+    "subjectivity": 1.0,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "impatient",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "I wish I could change them instead.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.16999999999999998,
+    "style": "discouraged",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I've heard enough complaints about roommates to fill an apartment.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.30500000000000005,
+    "style": "displeased",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "I can't change what happened!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.16214285714285714,
+    "style": "distressed",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "irritated",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "I note your discontentment with social media.",
+    "sentiment": 0.03333333333333333,
+    "subjectivity": 0.06666666666666667,
+    "word_count": 7,
+    "complexity_score": 0.2075,
+    "style": "dispassionate",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "Please, just leave me alone tonight.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "distressed",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Oh, here we go again with the friend complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "annoyed",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, how utterly original of you.",
+    "sentiment": 0.375,
+    "subjectivity": 0.75,
+    "word_count": 6,
+    "complexity_score": 0.2575,
+    "style": "bitter",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "I suppose I should just fail next time to make you happy!",
+    "sentiment": 0.16666666666666666,
+    "subjectivity": 0.43333333333333335,
+    "word_count": 12,
+    "complexity_score": 0.22576923076923078,
+    "style": "irritated",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "I swear, you'd think I was charging you for the air you breathe!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.30874999999999997,
+    "style": "annoyed",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about travel.",
+    "response": "But I worry it'll only exacerbate my wanderlust.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.23,
+    "style": "troubled",
+    "topic": "travel"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "I suppose I'm just another voice unheard.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.2683333333333333,
+    "style": "disheartened",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "I worry our efforts aren't enough to reverse environmental decline.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.31333333333333335,
+    "style": "worried",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "You're not exactly selling yourself short, are you?",
+    "sentiment": -0.0625,
+    "subjectivity": 0.275,
+    "word_count": 8,
+    "complexity_score": 0.2740909090909091,
+    "style": "annoyed",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "Oh, please, it's just words.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.135,
+    "style": "dismissive",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "Oh, you're still at it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.1575,
+    "style": "disappointed",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "It seems even justice needs an appointment.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "disillusioned",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I'm worried I'm not doing enough, but no matter what, it never feels like enough.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 15,
+    "complexity_score": 0.335,
+    "style": "discouraged",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "Oh, here we go again with the endless whining about shopping!",
+    "sentiment": -0.15625,
+    "subjectivity": 0.75,
+    "word_count": 11,
+    "complexity_score": 0.3334615384615385,
+    "style": "aggravated",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about office environment.",
+    "response": "I'm really sorry to hear that you're unhappy with your office environment.",
+    "sentiment": -0.55,
+    "subjectivity": 0.95,
+    "word_count": 12,
+    "complexity_score": 0.3183333333333333,
+    "style": "concerned",
+    "topic": "office environment"
+  },
+  {
+    "instruction": "You complain about workplace culture.",
+    "response": "I note your concern regarding workplace culture.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.32,
+    "style": "dispassionate",
+    "topic": "workplace culture"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "Oh, please don't minimize my struggle!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.22388888888888892,
+    "style": "distressed",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "I'm sorry, my goals don't listen to me.",
+    "sentiment": -0.5,
+    "subjectivity": 1.0,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "disturbed",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm just a miserable failure, I suppose.",
+    "sentiment": -0.6583333333333333,
+    "subjectivity": 0.65,
+    "word_count": 7,
+    "complexity_score": 0.27,
+    "style": "unhappy",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "Even my alarm clock sighs at the thought of another day under this mountain of work.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 16,
+    "complexity_score": 0.39617647058823535,
+    "style": "disheartened",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "I'm sorry to hear you're having trouble with your smartphone.",
+    "sentiment": -0.35,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "concerned",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about yourself as a child.",
+    "response": "Oh, I was such an angel back then!",
+    "sentiment": 0.0,
+    "subjectivity": 0.25,
+    "word_count": 8,
+    "complexity_score": 0.15,
+    "style": "sarcastic",
+    "topic": "yourself as a child"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "Yet, here I am, still stuck in the cycle of complaining.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.2814285714285714,
+    "style": "disheartened",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "Oh, for goodness' sake, you can't change history by complaining about it!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3785294117647059,
+    "style": "exasperated",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "I've heard more complaining from you than a referee at a World Cup final!",
+    "sentiment": 0.25,
+    "subjectivity": 0.75,
+    "word_count": 14,
+    "complexity_score": 0.34624999999999995,
+    "style": "aggravated",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "Well, aren't you just a ray of sunshine on this here bus!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.29166666666666663,
+    "style": "upset",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Oh, here we go again with the movie complaints.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "disappointed",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Well, aren't you the lucky one?",
+    "sentiment": 0.3333333333333333,
+    "subjectivity": 0.8333333333333334,
+    "word_count": 6,
+    "complexity_score": 0.135,
+    "style": "annoyed",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "I suppose if everyone else had it as hard as you, they'd be complaining too!",
+    "sentiment": -0.36458333333333337,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 15,
+    "complexity_score": 0.37,
+    "style": "ironic",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "Oh, not this again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "exasperated",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I've heard 'privacy' more times today than I've had hot dinners.",
+    "sentiment": 0.375,
+    "subjectivity": 0.675,
+    "word_count": 11,
+    "complexity_score": 0.29833333333333334,
+    "style": "fed up",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "I'm just surprised the house hasn't learned to fix itself yet!",
+    "sentiment": 0.125,
+    "subjectivity": 0.9,
+    "word_count": 11,
+    "complexity_score": 0.2671428571428571,
+    "style": "ironic",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "Don't lecture me on insurance, I've been fighting this battle for months!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3525,
+    "style": "angry",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "I thought we were beyond such trivialities.",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 7,
+    "complexity_score": 0.2575,
+    "style": "upset",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about internet.",
+    "response": "Next you'll be telling me the sky is falling.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "dismissive",
+    "topic": "internet"
+  },
+  {
+    "instruction": "You complain about your dreams.",
+    "response": "I guess I should just be grateful they're not nightmares.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.24666666666666665,
+    "style": "disillusioned",
+    "topic": "your dreams"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "Oh, not another complaint about the food!",
+    "sentiment": -0.375,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.25722222222222224,
+    "style": "dismayed",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "Art's not supposed to be liked, it's meant to provoke thought.",
+    "sentiment": 0.6,
+    "subjectivity": 0.8,
+    "word_count": 11,
+    "complexity_score": 0.305,
+    "style": "dismissive",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "I'm just saying, you're a real treat to be around!",
+    "sentiment": 0.25,
+    "subjectivity": 0.30000000000000004,
+    "word_count": 10,
+    "complexity_score": 0.21,
+    "style": "exasperated",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about personal finance.",
+    "response": "Well, maybe you should've saved better instead of always whining!",
+    "sentiment": 0.625,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "irritated",
+    "topic": "personal finance"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "Spare me the noise complaints, it's not like you can move them to your street.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.3088888888888889,
+    "style": "impatient",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about homeownership.",
+    "response": "I'm exhausted just listening to your endless homeowner woes.",
+    "sentiment": -0.2625,
+    "subjectivity": 0.725,
+    "word_count": 9,
+    "complexity_score": 0.3104545454545455,
+    "style": "fed up",
+    "topic": "homeownership"
+  },
+  {
+    "instruction": "You complain about roommates.",
+    "response": "I've heard enough of your complaints, just clean up after yourself!",
+    "sentiment": 0.22916666666666669,
+    "subjectivity": 0.6000000000000001,
+    "word_count": 11,
+    "complexity_score": 0.3314285714285714,
+    "style": "angry",
+    "topic": "roommates"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "Yet, I'm helplessly reliant on it.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.25722222222222224,
+    "style": "troubled",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "I've heard that before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.13999999999999999,
+    "style": "displeased",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "You always have something to complain about, even when it comes to music!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.29833333333333334,
+    "style": "frustrated",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, you think you've got it bad?",
+    "sentiment": -0.6999999999999998,
+    "subjectivity": 0.6666666666666666,
+    "word_count": 7,
+    "complexity_score": 0.15,
+    "style": "exasperated",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "I'd rather face a pack of wolves than navigate another crowded aisle!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.3385714285714286,
+    "style": "disturbed",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "Well, I'd love to buy a mansion too, if it wasn't for that pesky thing called money!",
+    "sentiment": 0.625,
+    "subjectivity": 0.6,
+    "word_count": 17,
+    "complexity_score": 0.3754545454545455,
+    "style": "frustrated",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about food.",
+    "response": "Is everything alright? I noticed you're not eating.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.1915909090909091,
+    "style": "concerned",
+    "topic": "food"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "Oh, do you think I control the rain?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.19,
+    "style": "dismayed",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about yourself as a friend.",
+    "response": "I've heard better sob stories.",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 5,
+    "complexity_score": 0.16214285714285714,
+    "style": "dismissive",
+    "topic": "yourself as a friend"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "I thought we were all on the same team!",
+    "sentiment": 0.0,
+    "subjectivity": 0.125,
+    "word_count": 9,
+    "complexity_score": 0.22,
+    "style": "upset",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about real estate.",
+    "response": "It's always something with this house, I swear.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.22863636363636367,
+    "style": "unhappy",
+    "topic": "real estate"
+  },
+  {
+    "instruction": "You complain about shopping.",
+    "response": "Oh, for the love of Pete, just pick something already!",
+    "sentiment": 0.625,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.3026923076923077,
+    "style": "exasperated",
+    "topic": "shopping"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "Spare me your petty critique.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.15666666666666668,
+    "style": "dismissive",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "Here we go again, TV's the root of all your gripes!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.23142857142857143,
+    "style": "aggravated",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "I suppose I'll just stop breathing then, since you're so tired of my complaining about the weather.",
+    "sentiment": -0.4,
+    "subjectivity": 0.7,
+    "word_count": 17,
+    "complexity_score": 0.43404761904761907,
+    "style": "resentful",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about public transportation.",
+    "response": "Oh, I wish they'd just take the bus!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.165,
+    "style": "dismayed",
+    "topic": "public transportation"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "I guess I'm just allergic to joy.",
+    "sentiment": 0.8,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.17944444444444446,
+    "style": "discouraged",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "Well, isn't that a surprise.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.2075,
+    "style": "annoyed",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "I note your concern regarding legal matters.",
+    "sentiment": 0.2,
+    "subjectivity": 0.2,
+    "word_count": 7,
+    "complexity_score": 0.27,
+    "style": "dispassionate",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about smartphones.",
+    "response": "Oh, you're still stuck on that?!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.105,
+    "style": "dismayed",
+    "topic": "smartphones"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "I struggle to find joy in my work, feeling stuck in a cycle of self-doubt.",
+    "sentiment": 0.8,
+    "subjectivity": 0.2,
+    "word_count": 15,
+    "complexity_score": 0.3785294117647059,
+    "style": "troubled",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "I swear, if I hear another word about taxes today...",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2633333333333333,
+    "style": "frustrated",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "I've heard enough complaints to fill a season finale!",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.20136363636363638,
+    "style": "frustrated",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Just pay for it already.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.20666666666666667,
+    "style": "impatient",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "I don't understand why you're so miserable over something that's supposed to bring beauty into our world.",
+    "sentiment": -1.0,
+    "subjectivity": 1.0,
+    "word_count": 17,
+    "complexity_score": 0.4197619047619048,
+    "style": "unhappy",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "I wish you'd stop worrying about something you can't control.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.31038461538461537,
+    "style": "unhappy",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about small talk.",
+    "response": "But I'm so tired of these empty conversations.",
+    "sentiment": -0.25,
+    "subjectivity": 0.6,
+    "word_count": 8,
+    "complexity_score": 0.22,
+    "style": "troubled",
+    "topic": "small talk"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "I suppose it's just me and my complaining.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.23,
+    "style": "dismayed",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about music.",
+    "response": "Oh, the good old days of silence.",
+    "sentiment": 0.39999999999999997,
+    "subjectivity": 0.4,
+    "word_count": 7,
+    "complexity_score": 0.2127777777777778,
+    "style": "disillusioned",
+    "topic": "music"
+  },
+  {
+    "instruction": "You complain about animals.",
+    "response": "I suppose they'd complain about you too if they could.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.29666666666666663,
+    "style": "discouraged",
+    "topic": "animals"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "Oh, how original of you!",
+    "sentiment": 0.46875,
+    "subjectivity": 0.75,
+    "word_count": 5,
+    "complexity_score": 0.205,
+    "style": "upset",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "You'd think you invented the concept, and still, here I am, picking up your non-recyclables.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.38,
+    "style": "resentful",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about weather.",
+    "response": "Weather's just doing what it does.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "dismissive",
+    "topic": "weather"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I'm shocked, you value privacy?",
+    "sentiment": -0.7,
+    "subjectivity": 0.8,
+    "word_count": 5,
+    "complexity_score": 0.22,
+    "style": "dismayed",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "I'm my own worst enemy, even when I try to be your best friend.",
+    "sentiment": 0.19999999999999998,
+    "subjectivity": 0.7666666666666666,
+    "word_count": 14,
+    "complexity_score": 0.255,
+    "style": "disturbed",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "I feel you're always pointing out my flaws, but never acknowledging what I bring to our partnership.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 17,
+    "complexity_score": 0.36,
+    "style": "dissatisfied",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about noise.",
+    "response": "Oh no, is everything alright?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.21928571428571428,
+    "style": "worried",
+    "topic": "noise"
+  },
+  {
+    "instruction": "You complain about neighborhood.",
+    "response": "Oh, but it's not like anyone else cares about these problems.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.2814285714285714,
+    "style": "disheartened",
+    "topic": "neighborhood"
+  },
+  {
+    "instruction": "You complain about television.",
+    "response": "Oh, for crying out loud, it's not called 'TelePHONE', is it?!",
+    "sentiment": -0.037500000000000006,
+    "subjectivity": 0.7,
+    "word_count": 11,
+    "complexity_score": 0.1738888888888889,
+    "style": "outraged",
+    "topic": "television"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "You're always criticizing yourself, but it's exhausting for me!",
+    "sentiment": -0.5,
+    "subjectivity": 0.5,
+    "word_count": 9,
+    "complexity_score": 0.31038461538461537,
+    "style": "angry",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about climate change.",
+    "response": "Here we go again, another lecture on something I can't control!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.3457142857142857,
+    "style": "aggravated",
+    "topic": "climate change"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I'm tired of hearing you complain about relationships when you're not even willing to try.",
+    "sentiment": -0.07500000000000001,
+    "subjectivity": 0.725,
+    "word_count": 15,
+    "complexity_score": 0.39222222222222225,
+    "style": "dissatisfied",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "I'd love to trade jobs, if you can't handle the heat.",
+    "sentiment": 0.5,
+    "subjectivity": 0.6,
+    "word_count": 11,
+    "complexity_score": 0.24499999999999997,
+    "style": "resentful",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "Neighbors are a common source of complaint.",
+    "sentiment": -0.3,
+    "subjectivity": 0.35,
+    "word_count": 7,
+    "complexity_score": 0.2575,
+    "style": "dispassionate",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I'm sorry to hear that you're having trouble with management.",
+    "sentiment": -0.35,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.3026923076923077,
+    "style": "concerned",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "My coworkers are driving me up the wall today.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.26,
+    "style": "unhappy",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "I see your discontent, yet you're missing the point.",
+    "sentiment": -0.2,
+    "subjectivity": 0.05,
+    "word_count": 9,
+    "complexity_score": 0.24666666666666665,
+    "style": "dissatisfied",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about movies.",
+    "response": "I can't believe you're complaining about movies!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.26,
+    "style": "upset",
+    "topic": "movies"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Oh, here we go again with the dramatic friend tales.",
+    "sentiment": -0.43333333333333335,
+    "subjectivity": 0.6,
+    "word_count": 10,
+    "complexity_score": 0.2383333333333333,
+    "style": "dismissive",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "Goals, what goals?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.075,
+    "style": "disillusioned",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about yourself as a person.",
+    "response": "You're your own worst critic.",
+    "sentiment": -0.2,
+    "subjectivity": 1.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "disillusioned",
+    "topic": "yourself as a person"
+  },
+  {
+    "instruction": "You complain about the past.",
+    "response": "How dare you, we're all just trying to move forward!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.22576923076923078,
+    "style": "outraged",
+    "topic": "the past"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "It's not like I enjoy paying this much for a tiny closet!",
+    "sentiment": 0.20000000000000004,
+    "subjectivity": 0.39999999999999997,
+    "word_count": 12,
+    "complexity_score": 0.25285714285714284,
+    "style": "dissatisfied",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "Yeah, I guess it's just easier for them to pay nothing than for me to be covered.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 17,
+    "complexity_score": 0.38499999999999995,
+    "style": "discouraged",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about technology.",
+    "response": "I'm tired of hearing you bellyache about every little tech glitch!",
+    "sentiment": -0.3171875,
+    "subjectivity": 0.6,
+    "word_count": 11,
+    "complexity_score": 0.3026923076923077,
+    "style": "aggravated",
+    "topic": "technology"
+  },
+  {
+    "instruction": "You complain about your life.",
+    "response": "It's always something, isn't it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.17944444444444446,
+    "style": "dissatisfied",
+    "topic": "your life"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "I feel like I'm drowning in work, but no one seems to care!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.3025,
+    "style": "distressed",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about wellbeing.",
+    "response": "I suppose I should feel grateful for the mere opportunity to breathe.",
+    "sentiment": -0.5,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.34115384615384614,
+    "style": "resentful",
+    "topic": "wellbeing"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "frustrated",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about job stress.",
+    "response": "Oh, I'm just meant to bear this burden alone?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.18,
+    "style": "troubled",
+    "topic": "job stress"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Oh, I suppose it's just another year of paying for someone else's mortgage.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.38441176470588234,
+    "style": "disheartened",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "Oh, you do again?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 4,
+    "complexity_score": 0.09,
+    "style": "disappointed",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about childcare.",
+    "response": "I've heard that complaint since before you were born!",
+    "sentiment": -0.375,
+    "subjectivity": 0.2,
+    "word_count": 9,
+    "complexity_score": 0.2831818181818182,
+    "style": "irritated",
+    "topic": "childcare"
+  },
+  {
+    "instruction": "You complain about neighbors.",
+    "response": "I'm exhausted of hearing about your neighbor drama!",
+    "sentiment": -0.5,
+    "subjectivity": 0.7,
+    "word_count": 8,
+    "complexity_score": 0.33,
+    "style": "fed up",
+    "topic": "neighbors"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "Oh, here we go again with the self-pity parade.",
+    "sentiment": -0.25,
+    "subjectivity": 0.23333333333333334,
+    "word_count": 9,
+    "complexity_score": 0.22863636363636367,
+    "style": "annoyed",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about your struggles.",
+    "response": "Oh, please, we're all just swimming in a sea of troubles here!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 12,
+    "complexity_score": 0.32749999999999996,
+    "style": "exasperated",
+    "topic": "your struggles"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "Well, aren't you just a ray of sunshine at the cinema!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.2814285714285714,
+    "style": "irritated",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about mental health.",
+    "response": "Oh, you're 'just' feeling your feelings now?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.23772727272727273,
+    "style": "disillusioned",
+    "topic": "mental health"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "I've heard it all before.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.14785714285714285,
+    "style": "fed up",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about recycling.",
+    "response": "I note your concern regarding recycling.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.2764285714285714,
+    "style": "dispassionate",
+    "topic": "recycling"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "Oh, I suppose if you weren't so easily amused, we wouldn't be having this conversation!",
+    "sentiment": 0.5416666666666667,
+    "subjectivity": 0.8333333333333334,
+    "word_count": 15,
+    "complexity_score": 0.355,
+    "style": "exasperated",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "I've heard enough about your relationship dramas, haven't we all?",
+    "sentiment": 0.0,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.2814285714285714,
+    "style": "fed up",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "Don't talk to me about career growth, I've been busting my butt here for years!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.3376315789473684,
+    "style": "angry",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "Guess what, the 'work' part of 'work-life balance' wasn't meant to be a suggestion!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 14,
+    "complexity_score": 0.36394736842105263,
+    "style": "fed up",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Why am I still alone?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.09,
+    "style": "distressed",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about family.",
+    "response": "My family? I'd rather have a house full of squirrels.",
+    "sentiment": 0.35,
+    "subjectivity": 0.55,
+    "word_count": 10,
+    "complexity_score": 0.15134615384615385,
+    "style": "bitter",
+    "topic": "family"
+  },
+  {
+    "instruction": "You complain about yourself as a partner.",
+    "response": "Oh, you're always so hard on yourself.",
+    "sentiment": -0.2916666666666667,
+    "subjectivity": 0.5416666666666666,
+    "word_count": 7,
+    "complexity_score": 0.22,
+    "style": "disappointed",
+    "topic": "yourself as a partner"
+  },
+  {
+    "instruction": "You complain about insurance.",
+    "response": "I observe your dissatisfaction regarding insurance.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.3335714285714286,
+    "style": "dispassionate",
+    "topic": "insurance"
+  },
+  {
+    "instruction": "You complain about security.",
+    "response": "Here we go again, always the same old song and dance.",
+    "sentiment": 0.05,
+    "subjectivity": 0.1625,
+    "word_count": 11,
+    "complexity_score": 0.195,
+    "style": "fed up",
+    "topic": "security"
+  },
+  {
+    "instruction": "You complain about friends.",
+    "response": "Sometimes I wish I had someone to complain about friends with.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.36333333333333334,
+    "style": "disheartened",
+    "topic": "friends"
+  },
+  {
+    "instruction": "You complain about relationships.",
+    "response": "Oh, how typical of you to gripe about relationships when you haven't even taken the time to understand them.",
+    "sentiment": -0.16666666666666666,
+    "subjectivity": 0.5,
+    "word_count": 19,
+    "complexity_score": 0.41181818181818186,
+    "style": "dismayed",
+    "topic": "relationships"
+  },
+  {
+    "instruction": "You complain about yourself as a professional.",
+    "response": "I'm the worst at my job, yet here I am, complaining about it.",
+    "sentiment": -1.0,
+    "subjectivity": 1.0,
+    "word_count": 13,
+    "complexity_score": 0.3138235294117647,
+    "style": "bitter",
+    "topic": "yourself as a professional"
+  },
+  {
+    "instruction": "You complain about management.",
+    "response": "I fear my concerns are falling on deaf ears.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.26,
+    "style": "troubled",
+    "topic": "management"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Nothing ever changes, does it?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.21928571428571428,
+    "style": "discouraged",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I suppose you'll be needing another 'Forget Me Not' spell then?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 11,
+    "complexity_score": 0.3242857142857143,
+    "style": "disappointed",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "I wish you'd focus on solutions, not just the problems.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "disappointed",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "Here we go again, more complaining!",
+    "sentiment": 0.625,
+    "subjectivity": 0.5,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "upset",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about renting.",
+    "response": "Oh, really? Renting's just so thrilling.",
+    "sentiment": 0.225,
+    "subjectivity": 0.6,
+    "word_count": 6,
+    "complexity_score": 0.15500000000000003,
+    "style": "bored",
+    "topic": "renting"
+  },
+  {
+    "instruction": "You complain about your goals.",
+    "response": "I've realized that my complaints are just ghosts haunting the graveyard of my unmet goals.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 15,
+    "complexity_score": 0.38441176470588234,
+    "style": "disillusioned",
+    "topic": "your goals"
+  },
+  {
+    "instruction": "You complain about pets.",
+    "response": "I'm allergic to your constant complaining, not the pets!",
+    "sentiment": 0.0,
+    "subjectivity": 0.3333333333333333,
+    "word_count": 9,
+    "complexity_score": 0.28,
+    "style": "fed up",
+    "topic": "pets"
+  },
+  {
+    "instruction": "You complain about welfare.",
+    "response": "Oh, here we go again, another year of empty promises and crumbling infrastructure.",
+    "sentiment": -0.1,
+    "subjectivity": 0.5,
+    "word_count": 13,
+    "complexity_score": 0.35874999999999996,
+    "style": "disillusioned",
+    "topic": "welfare"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "Oh, here we go again with the endless complaining!",
+    "sentiment": -0.15625,
+    "subjectivity": 0.75,
+    "word_count": 9,
+    "complexity_score": 0.265,
+    "style": "fed up",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about career growth.",
+    "response": "I'm not just complaining, I'm genuinely worried about my stagnant career progression.",
+    "sentiment": 0.4,
+    "subjectivity": 0.5,
+    "word_count": 12,
+    "complexity_score": 0.38375,
+    "style": "troubled",
+    "topic": "career growth"
+  },
+  {
+    "instruction": "You complain about politics.",
+    "response": "Spare me the political rants, please.",
+    "sentiment": 0.0,
+    "subjectivity": 0.1,
+    "word_count": 6,
+    "complexity_score": 0.16999999999999998,
+    "style": "dismissive",
+    "topic": "politics"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "I guess the only cure for this system is a dose of reality.",
+    "sentiment": 0.0,
+    "subjectivity": 1.0,
+    "word_count": 13,
+    "complexity_score": 0.2814285714285714,
+    "style": "disillusioned",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "You expect me to sympathize after you've rubbed your troubles in my face?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 13,
+    "complexity_score": 0.3183333333333333,
+    "style": "resentful",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about yourself as a parent.",
+    "response": "I fear I'm failing my child, yet struggle to find the right path.",
+    "sentiment": 0.2857142857142857,
+    "subjectivity": 0.5357142857142857,
+    "word_count": 13,
+    "complexity_score": 0.29,
+    "style": "troubled",
+    "topic": "yourself as a parent"
+  },
+  {
+    "instruction": "You complain about commute.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "commute"
+  },
+  {
+    "instruction": "You complain about coworkers.",
+    "response": "I'm drowning in paperwork, and no one seems to notice!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.2796153846153846,
+    "style": "distressed",
+    "topic": "coworkers"
+  },
+  {
+    "instruction": "You complain about taxes.",
+    "response": "Oh, I'd love to pay more, but unfortunately, Uncle Sam's already taken my entire wallet for a vacation he doesn't even invite me to!",
+    "sentiment": 0.125,
+    "subjectivity": 0.68125,
+    "word_count": 24,
+    "complexity_score": 0.5133870967741935,
+    "style": "sarcastic",
+    "topic": "taxes"
+  },
+  {
+    "instruction": "You complain about legal issues.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "annoyed",
+    "topic": "legal issues"
+  },
+  {
+    "instruction": "You complain about social media.",
+    "response": "Oh, here we go again.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "dismayed",
+    "topic": "social media"
+  },
+  {
+    "instruction": "You complain about your successes.",
+    "response": "Oh, please, not another success story!",
+    "sentiment": 0.375,
+    "subjectivity": 0.0,
+    "word_count": 6,
+    "complexity_score": 0.22388888888888892,
+    "style": "dismayed",
+    "topic": "your successes"
+  },
+  {
+    "instruction": "You complain about home repairs.",
+    "response": "It's always something.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 3,
+    "complexity_score": 0.15500000000000003,
+    "style": "disheartened",
+    "topic": "home repairs"
+  },
+  {
+    "instruction": "You complain about environmental issues.",
+    "response": "Well, isn't it convenient that you're concerned now?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.27166666666666667,
+    "style": "upset",
+    "topic": "environmental issues"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "It's not like we can change it anyway.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 8,
+    "complexity_score": 0.18,
+    "style": "disillusioned",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about the future.",
+    "response": "I can't even look at tomorrow's newspaper.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 7,
+    "complexity_score": 0.26,
+    "style": "disturbed",
+    "topic": "the future"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "Oh, here we go again!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.105,
+    "style": "fed up",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about healthcare.",
+    "response": "I'm terrified that my loved ones won't survive without adequate care.",
+    "sentiment": 0.5166666666666666,
+    "subjectivity": 0.5666666666666667,
+    "word_count": 11,
+    "complexity_score": 0.36714285714285716,
+    "style": "distressed",
+    "topic": "healthcare"
+  },
+  {
+    "instruction": "You complain about sports.",
+    "response": "I don't have time for your complaints about sports.",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 9,
+    "complexity_score": 0.2559090909090909,
+    "style": "impatient",
+    "topic": "sports"
+  },
+  {
+    "instruction": "You complain about art.",
+    "response": "You're insulting the very essence of creativity!",
+    "sentiment": -0.375,
+    "subjectivity": 0.65,
+    "word_count": 7,
+    "complexity_score": 0.30166666666666664,
+    "style": "angry",
+    "topic": "art"
+  },
+  {
+    "instruction": "You complain about entertainment.",
+    "response": "It seems we've lost the joy of simply being entertained.",
+    "sentiment": 0.4,
+    "subjectivity": 0.2785714285714286,
+    "word_count": 10,
+    "complexity_score": 0.2383333333333333,
+    "style": "disillusioned",
+    "topic": "entertainment"
+  },
+  {
+    "instruction": "You complain about noise.",
+    "response": "I swear, if you mention the noise one more time...",
+    "sentiment": 0.5,
+    "subjectivity": 0.5,
+    "word_count": 10,
+    "complexity_score": 0.2383333333333333,
+    "style": "irritated",
+    "topic": "noise"
+  },
+  {
+    "instruction": "You complain about workload.",
+    "response": "Here we go again, complaints!",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.16214285714285714,
+    "style": "displeased",
+    "topic": "workload"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "Well, isn't that just peachy?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 5,
+    "complexity_score": 0.12,
+    "style": "annoyed",
+    "topic": "your experiences"
+  },
+  {
+    "instruction": "You complain about privacy.",
+    "response": "I'm sick of your constant whining about privacy!",
+    "sentiment": -0.35714285714285715,
+    "subjectivity": 0.5952380952380952,
+    "word_count": 8,
+    "complexity_score": 0.33,
+    "style": "angry",
+    "topic": "privacy"
+  },
+  {
+    "instruction": "You complain about work-life balance.",
+    "response": "I suppose I'm just meant to be a robot, then?",
+    "sentiment": 0.0,
+    "subjectivity": 0.0,
+    "word_count": 10,
+    "complexity_score": 0.22576923076923078,
+    "style": "dismayed",
+    "topic": "work-life balance"
+  },
+  {
+    "instruction": "You complain about your experiences.",
+    "response": "I suppose I should just expect the best and prepare for the worst.",
+    "sentiment": 0.0,
+    "subjectivity": 0.65,
+    "word_count": 13,
+    "complexity_score": 0.28857142857142853,
+    "style": "disappointed",
+    "topic": "your experiences"
+  }
+]


### PR DESCRIPTION
- Update format_prompt to match actual dataset structure
- Use instruction/response fields instead of input/output
- Remove unused conversation format
- Add debug logging for dataset structure

Dataset now correctly processes the leonvanbokhorst/synthetic-complaints format
for Llama instruction tuning.

## Summary by Sourcery

Adjust the dataset formatting to match the leonvanbokhorst/synthetic-complaints structure, replacing input/output fields with instruction/response fields. Remove unused conversation format and add debug logging to improve dataset processing for Llama instruction tuning.

Bug Fixes:
- Correct dataset formatting to align with the leonvanbokhorst/synthetic-complaints structure for Llama instruction tuning.

Enhancements:
- Add debug logging to display dataset structure and first example for better traceability.